### PR TITLE
Fix installing dependency otf-fea-rs

### DIFF
--- a/crates/fonttools-cli/Cargo.toml
+++ b/crates/fonttools-cli/Cargo.toml
@@ -15,5 +15,5 @@ kurbo = { version = "0.8.1" }
 chrono = { version = "0.4.3" }
 log = "0.4.14"
 env_logger = "0.8"
-otf-fea-rs = {  git = "https://github.com/wrl/otf-fea-rs" }
+otf-fea-rs = {  git = "https://github.com/wrl/otf-fea-rs", branch = "trunk" }
 rayon = "1.0.1"


### PR DESCRIPTION
[otf-fea-rs](https://github.com/wrl/otf-fea-rs) doesn't contain a master branch. Its default branch is "trunk".