### PR TITLE
Change Win EncodingID to 1

### DIFF
--- a/src/name.rs
+++ b/src/name.rs
@@ -137,7 +137,7 @@ pub struct NameRecord {
 
 impl NameRecord {
     /// Create a new name record for the Windows platform in Unicode encoding
-    /// (3,10,0x409)
+    /// (3,1,0x409)
     pub fn windows_unicode<T, U>(n: T, s: U) -> NameRecord
     where
         T: Into<u16>,
@@ -145,7 +145,7 @@ impl NameRecord {
     {
         NameRecord {
             platformID: 3,
-            encodingID: 10,
+            encodingID: 1,
             languageID: 0x409,
             nameID: n.into(),
             string: s.into(),

--- a/src/name.rs
+++ b/src/name.rs
@@ -137,7 +137,8 @@ pub struct NameRecord {
 
 impl NameRecord {
     /// Create a new name record for the Windows platform in Unicode encoding
-    /// (3,1,0x409)
+    /// (3,1,0x409) if all characters are in the Basic Multilingual Plane (BMP)
+    /// otherwise use (3,10,0x409)
     pub fn windows_unicode<T, U>(n: T, s: U) -> NameRecord
     where
         T: Into<u16>,

--- a/src/name.rs
+++ b/src/name.rs
@@ -143,12 +143,13 @@ impl NameRecord {
         T: Into<u16>,
         U: Into<String>,
     {
+        let record_string = s.into();
         NameRecord {
             platformID: 3,
-            encodingID: 1,
+            encodingID: if record_string.chars().any(|c| c as u32 > 0xffff) { 10 } else { 1 },
             languageID: 0x409,
             nameID: n.into(),
-            string: s.into(),
+            string: record_string,
         }
     }
 }


### PR DESCRIPTION
This matches fontmake and it's also recommended in the ms spec

> When building a Unicode font for Windows, the platform ID should be 3 and the encoding ID should be 1, and the referenced string data must be encoded in UTF-16BE.

https://docs.microsoft.com/en-us/typography/opentype/spec/name#platform-specific-encoding-and-language-ids-windows-platform-platform-id-3