### PR TITLE
Enable feature "is_sorted"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![warn(missing_docs, missing_crate_level_docs)]
 #![allow(non_camel_case_types, non_snake_case, clippy::upper_case_acronyms)]
+#![feature(is_sorted)]
 
 /// The `avar` (Axis variations) table
 pub mod avar;


### PR DESCRIPTION
Commit https://github.com/simoncozens/fonttools-rs/commit/9b33db9a20bc2f190984751d5c40e9a13129b869 uses the unstable library feature "is_sorted". If I run `build cargo`, I get the following traceback:

```
error[E0658]: use of unstable library feature 'is_sorted': new API
  --> src/layout/coverage.rs:73:29
   |
73 |             || !self.glyphs.is_sorted()
   |                             ^^^^^^^^^
   |
   = note: see issue #53485 <https://github.com/rust-lang/rust/issues/53485> for more information
   = help: add `#![feature(is_sorted)]` to the crate attributes to enable

error: aborting due to previous error
```

To fix, I simply followed the above instructions. ❤️  the Rust compiler.

btw, I updated Nightly before doing this and it didn't solve it.