### PR TITLE
Get running on stable rust

### DIFF
--- a/crates/otspec_macros/Cargo.toml
+++ b/crates/otspec_macros/Cargo.toml
@@ -10,3 +10,4 @@ proc-macro = true
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4.3" }
+quote = "1.0"

--- a/src/layout/coverage.rs
+++ b/src/layout/coverage.rs
@@ -62,6 +62,23 @@ fn consecutive_slices(data: &[uint16]) -> Vec<&[uint16]> {
     result
 }
 
+// TODO: delete when `is_sorted` stablizes: https://github.com/rust-lang/rust/issues/53485
+// copied from stdlib
+fn is_sorted<T: Ord>(slice: &[T]) -> bool {
+    let mut iter = slice.iter();
+    let mut prev = match iter.next() {
+        Some(x) => x,
+        None => return true,
+    };
+    while let Some(next) = iter.next() {
+        if next < prev {
+            return false;
+        }
+        prev = next;
+    }
+    true
+}
+
 impl Serialize for Coverage {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -70,7 +87,7 @@ impl Serialize for Coverage {
         let mut seq = serializer.serialize_seq(None)?;
         let as_consecutive = consecutive_slices(&self.glyphs);
         if self.glyphs.is_empty()
-            || !self.glyphs.is_sorted()
+            || !is_sorted(&self.glyphs)
             || as_consecutive.len() * 3 > self.glyphs.len()
         {
             seq.serialize_element::<uint16>(&1)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![warn(missing_docs, missing_crate_level_docs)]
 #![allow(non_camel_case_types, non_snake_case, clippy::upper_case_acronyms)]
-#![feature(is_sorted)]
 
 /// The `GSUB` (Glyph substitution) table
 pub mod GSUB;


### PR DESCRIPTION
We were using three unstable features.

`is_sorted`:

I have replaced the use of nightly with a manual implementation.

`proc_macro_quote`:

Apparently unused? I've removed this feature.

`proc_macro_diagnostic`:

used in two functions; I have provided non-nightly alternatives.

I'm extremely not-confident about what my version of these functions
are actually doing, but I'm happy to just get compilation working
and then we can worry about things like "being useful" a bit later?