### PR TITLE
Clippy and cleanup

### DIFF
--- a/crates/otspec/src/de.rs
+++ b/crates/otspec/src/de.rs
@@ -1,10 +1,9 @@
-use crate::error::{Error, Result};
-use serde::de::{
-    self, Deserialize, DeserializeSeed, EnumAccess, IntoDeserializer, MapAccess, SeqAccess,
-    VariantAccess, Visitor,
-};
 use std::convert::TryInto;
 use std::mem;
+
+use serde::de::{self, Deserialize, DeserializeSeed, SeqAccess, Visitor};
+
+use crate::error::{Error, Result};
 
 pub struct Deserializer<'de> {
     // This string starts with the input data and characters are truncated off
@@ -128,14 +127,14 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         unimplemented!()
     }
 
-    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>
+    fn deserialize_str<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
         unimplemented!()
     }
 
-    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value>
+    fn deserialize_string<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
@@ -166,7 +165,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     }
 
     // In Serde, unit means an anonymous value containing no data.
-    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value>
+    fn deserialize_unit<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
@@ -188,7 +187,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         visitor.visit_newtype_struct(self)
     }
 
-    fn deserialize_seq<V>(mut self, visitor: V) -> Result<V::Value>
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
@@ -214,7 +213,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         self.deserialize_seq(visitor)
     }
 
-    fn deserialize_map<V>(mut self, visitor: V) -> Result<V::Value>
+    fn deserialize_map<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
@@ -237,7 +236,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         self,
         _name: &'static str,
         _variants: &'static [&'static str],
-        visitor: V,
+        _visitor: V,
     ) -> Result<V::Value>
     where
         V: Visitor<'de>,
@@ -245,14 +244,14 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         Err(Error::ExpectedEnum)
     }
 
-    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value>
+    fn deserialize_identifier<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
         unimplemented!()
     }
 
-    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value>
+    fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {

--- a/crates/otspec/src/error.rs
+++ b/crates/otspec/src/error.rs
@@ -1,4 +1,3 @@
-use std;
 use std::fmt::{self, Display};
 
 use serde::{de, ser};

--- a/crates/otspec/src/ser.rs
+++ b/crates/otspec/src/ser.rs
@@ -1,6 +1,5 @@
 use crate::error::{Error, Result};
 use serde::{ser, Serialize};
-use std::convert::TryInto;
 
 pub struct Serializer {
     output: Vec<u8>,
@@ -286,7 +285,7 @@ impl<'a> ser::SerializeStruct for &'a mut Serializer {
     type Ok = ();
     type Error = Error;
 
-    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<()>
     where
         T: ?Sized + Serialize,
     {
@@ -307,7 +306,7 @@ impl<'a> ser::SerializeStructVariant for &'a mut Serializer {
     type Ok = ();
     type Error = Error;
 
-    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<()>
     where
         T: ?Sized + Serialize,
     {

--- a/crates/otspec/src/types.rs
+++ b/crates/otspec/src/types.rs
@@ -1,15 +1,17 @@
 #![allow(unused_must_use, non_snake_case, non_camel_case_types)]
-use std::convert::TryInto;
+
 use std::fmt;
 
 use serde::de::{self, Visitor};
-use serde::{Serialize, Serializer};
 
 pub type uint16 = u16;
 pub type uint32 = u32;
 pub type int16 = i16;
 pub type Tag = [u8; 4];
+
+#[allow(clippy::upper_case_acronyms)]
 pub type FWORD = i16;
+#[allow(clippy::upper_case_acronyms)]
 pub type UFWORD = u16;
 
 fn ot_round(value: f32) -> i32 {
@@ -43,7 +45,7 @@ pub use Fixed as Version16Dot16;
 pub mod F2DOT14 {
     use crate::types::ot_round;
     use crate::types::I16Visitor;
-    use crate::types::I32Visitor;
+
     use serde::{Deserializer, Serializer};
     use std::convert::TryInto;
 
@@ -123,7 +125,7 @@ pub mod Counted {
     use serde::de::{SeqAccess, Visitor};
     use serde::ser::SerializeSeq;
     use serde::Serialize;
-    use serde::{Deserialize, Deserializer, Serializer};
+    use serde::{Deserializer, Serializer};
 
     pub fn serialize<S, T>(v: &[T], serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -203,8 +205,7 @@ pub mod Offset16 {
 pub mod Offset32 {
     use crate::error::Result;
     use crate::ser::SerializeOffsetStruct;
-    use serde::Serialize;
-    use serde::Serializer;
+    use serde::{Serialize, Serializer};
 
     pub fn serialize<S, T>(v: &T, mut serializer: S) -> Result<()>
     where
@@ -218,7 +219,6 @@ pub mod Offset32 {
 #[cfg(test)]
 mod tests {
     use crate::types::Counted;
-    use crate::types::Offset16;
     use crate::{de, ser};
     use serde::{Deserialize, Serialize};
 

--- a/src/font.rs
+++ b/src/font.rs
@@ -1,18 +1,17 @@
-use serde::de::SeqAccess;
-use serde::de::Visitor;
-use serde::{Deserialize, Deserializer};
-use serde::{Serialize, Serializer};
 use std::convert::{TryFrom, TryInto};
+use std::fs::File;
+use std::io::Write;
 use std::num::Wrapping;
-extern crate otspec;
+
+use indexmap::IndexMap;
+use otspec::types::*;
+use serde::de::{SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
 use crate::avar::avar;
 use crate::head::head;
 use crate::hhea::hhea;
 use crate::maxp::maxp;
-use indexmap::IndexMap;
-use otspec::types::*;
-use std::fs::File;
-use std::io::Write;
 
 #[derive(Debug, Serialize, PartialEq)]
 #[serde(untagged)]
@@ -50,6 +49,7 @@ struct TableRecord {
     length: uint32,
 }
 #[derive(Deserialize)]
+#[allow(non_snake_case)]
 struct TableHeader {
     sfntVersion: u32,
     numTables: u16,
@@ -195,7 +195,7 @@ impl<'de> Visitor<'de> for FontVisitor {
         write!(formatter, "A sequence of values")
     }
 
-    fn visit_seq<A: SeqAccess<'de>>(mut self, mut seq: A) -> Result<Self::Value, A::Error> {
+    fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
         let header = seq
             .next_element::<TableHeader>()?
             .ok_or_else(|| serde::de::Error::custom("Expecting a table header"))?;


### PR DESCRIPTION
- fixes a bunch of random clippy lints and warnings
- reoorders and cleans up imports where appropriate

Overall I tried not to be too invasive, and didn't touch anything
that I didn't understand.