### PR TITLE
Tweak load/save API

### DIFF
--- a/crates/fonttools-cli/src/bin/ttf-instantiate.rs
+++ b/crates/fonttools-cli/src/bin/ttf-instantiate.rs
@@ -3,10 +3,9 @@ use fonttools::otvar::instancer::{
     instantiate_variable_font, AxisRange, UserAxisLimit, UserAxisLimits,
 };
 use fonttools::types::*;
-use fonttools_cli::{open_font, save_font};
+use fonttools_cli::open_font;
 use regex::Regex;
 use std::collections::BTreeMap;
-use std::fs::File;
 use std::path::Path;
 
 fn main() {
@@ -53,19 +52,18 @@ fn main() {
 
     log::debug!("Axis limits = {:?}", limits);
     if instantiate_variable_font(&mut infont, limits) {
-        let mut out_fh = if let Some(out_fn) = matches.value_of("output") {
+        if let Some(out_fn) = matches.value_of("output") {
             log::info!("Saving on {}", out_fn);
-            File::create(out_fn)
+            infont.save(out_fn)
         } else {
             let input_filename = matches.value_of("INPUT").unwrap();
             let out_fn = Path::new(input_filename)
                 .with_extension("")
                 .with_extension("partial.ttf");
             log::info!("Saving on {}", out_fn.to_str().unwrap());
-            File::create(out_fn)
+            infont.save(out_fn)
         }
         .unwrap();
-        infont.save(&mut out_fh);
     }
 }
 

--- a/crates/fonttools-cli/src/lib.rs
+++ b/crates/fonttools-cli/src/lib.rs
@@ -17,8 +17,7 @@
 //!  * `ttf-rename-glyphs` - Renames glyphs to production names
 
 use clap::{App, Arg};
-use fonttools::font::{self, Font};
-use std::fs::File;
+use fonttools::font::Font;
 use std::io;
 
 pub fn read_args(name: &str, description: &str) -> clap::ArgMatches<'static> {
@@ -40,20 +39,18 @@ pub fn read_args(name: &str, description: &str) -> clap::ArgMatches<'static> {
 pub fn open_font(matches: &clap::ArgMatches) -> Font {
     if matches.is_present("INPUT") {
         let filename = matches.value_of("INPUT").unwrap();
-        let infile = File::open(filename).unwrap();
-        font::load(infile)
+        Font::load(filename)
     } else {
-        font::load(io::stdin())
+        Font::from_reader(io::stdin())
     }
     .expect("Could not parse font")
 }
 
 pub fn save_font(mut font: Font, matches: &clap::ArgMatches) {
-    if matches.is_present("OUTPUT") {
-        let mut outfile = File::create(matches.value_of("OUTPUT").unwrap())
-            .expect("Could not open file for writing");
-        font.save(&mut outfile);
+    if let Some(path) = matches.value_of("OUTPUT") {
+        font.save(path)
     } else {
-        font.save(&mut io::stdout());
-    };
+        font.write(io::stdout())
+    }
+    .expect("cound not save font")
 }

--- a/crates/otspec/examples/ttf-dump-graph.rs
+++ b/crates/otspec/examples/ttf-dump-graph.rs
@@ -1,11 +1,9 @@
 use clap::{App, Arg};
-use fonttools::font;
-use fonttools::font::Table;
+use fonttools::font::{Font, Table};
 use fonttools::MATH::MATHinternal;
 use otspec::types::{Offset16, OffsetMarkerTrait};
 use petgraph::dot::{Config, Dot};
 use petgraph::graph::{Graph, NodeIndex};
-use std::fs::File;
 
 fn main() {
     let matches = App::new("ttf-dump-graph")
@@ -22,9 +20,8 @@ fn main() {
         )
         .get_matches();
     let filename = matches.value_of("INPUT").unwrap();
-    let infile = File::open(filename).unwrap();
 
-    let mut infont = font::load(infile).unwrap();
+    let mut infont = Font::load(filename).unwrap();
     let table_name = matches.value_of("TABLE").unwrap();
 
     let mut dag: Graph<String, ()> = Graph::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,7 @@
 //! use fonttools::name::{name, NameRecord, NameRecordID};
 //!
 //! // Load a font (tables are lazy-loaded)
-//! let fontfile = File::open("Test.otf").unwrap();
-//! use std::fs::File;
-//! let mut myfont = font::load(fontfile).expect("Could not load font");
+//! let mut myfont = Font::load("Test.otf").expect("Could not load font");
 //!
 //! // Access an existing table
 //! if let Table::Name(name_table) = myfont.get_table(b"name")
@@ -24,8 +22,8 @@
 //!             "http://opensource.org/licenses/OFL-1.1"
 //!         ));
 //! }
-//! let mut outfile = File::create("Test-with-OFL.otf").expect("Could not create file");
-//! myfont.save(&mut outfile);
+//!
+//! myfont.save("Test-with-OFL.otf").expect("Could not create file");
 //! ```
 //! For information about creating and manipulating structures for
 //! each specific OpenType table, see the modules below. See


### PR DESCRIPTION
- Add Font::load and Font::from_bytes methods
- Change Font::save to take a path instead of a handle

This is hopefully a simpler API, not requiring the user to mess
around with files directly.

I'm not sure if there are uses for font::load that are not covered
by the new methods, so I have left it in place but marked it as
deprecated; if it should be removed I'm happy to make that change.