### PR TITLE
Replace 'serde' with 'otspec'

### DIFF
--- a/crates/otspec/src/lib.rs
+++ b/crates/otspec/src/lib.rs
@@ -155,7 +155,7 @@ pub trait Deserialize {
         Self: std::marker::Sized;
 }
 
-macro_rules! serde_primitive {
+macro_rules! otspec_primitive {
     ($t: ty) => {
         impl Serialize for $t {
             fn to_bytes(&self, data: &mut Vec<u8>) -> Result<(), SerializationError> {
@@ -181,13 +181,13 @@ macro_rules! serde_primitive {
     };
 }
 
-serde_primitive!(i8);
-serde_primitive!(u8);
-serde_primitive!(u16);
-serde_primitive!(u32);
-serde_primitive!(i16);
-serde_primitive!(i32);
-serde_primitive!(i64);
+otspec_primitive!(i8);
+otspec_primitive!(u8);
+otspec_primitive!(u16);
+otspec_primitive!(u32);
+otspec_primitive!(i16);
+otspec_primitive!(i32);
+otspec_primitive!(i64);
 
 impl<T> Serialize for Option<T>
 where

--- a/crates/otspec/src/offsetmanager.rs
+++ b/crates/otspec/src/offsetmanager.rs
@@ -169,7 +169,7 @@ mod tests {
 
     #[derive(Deserialize, Serialize, Debug, Clone)]
     struct One {
-        #[serde(offset_base)]
+        #[otspec(offset_base)]
         thing: uint16,
         anoffset: Offset16<Two>,
         other: uint16,
@@ -286,14 +286,14 @@ mod tests {
 
     #[derive(Deserialize, Serialize, Debug, Clone)]
     struct HasEmbedding {
-        #[serde(offset_base)]
+        #[otspec(offset_base)]
         thing: uint16,
-        #[serde(embed)]
+        #[otspec(embed)]
         notanoffset: TwoEmbedded,
     }
 
     #[derive(Deserialize, Debug, PartialEq, Serialize, Clone)]
-    #[serde(embedded)]
+    #[otspec(embedded)]
     struct TwoEmbedded {
         test1: uint16,
         deep: Offset16<Three>,
@@ -329,10 +329,10 @@ mod tests {
 
     #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
     struct HasEmbeddingArray {
-        #[serde(offset_base)]
+        #[otspec(offset_base)]
         thing: uint16,
-        #[serde(embed)]
-        #[serde(with = "Counted")]
+        #[otspec(embed)]
+        #[otspec(with = "Counted")]
         pub embed_array: Vec<TwoEmbedded>,
     }
 

--- a/crates/otspec/src/offsets.rs
+++ b/crates/otspec/src/offsets.rs
@@ -411,7 +411,7 @@ mod tests {
 
     #[derive(Deserialize, Debug, PartialEq, Serialize, Clone)]
     struct Two {
-        #[serde(offset_base)]
+        #[otspec(offset_base)]
         test1: uint16,
         deep: Offset16<Three>,
         test2: uint16,

--- a/crates/otspec_macros/src/internals/symbol.rs
+++ b/crates/otspec_macros/src/internals/symbol.rs
@@ -7,7 +7,7 @@ pub struct Symbol(&'static str);
 pub const DESERIALIZE_WITH: Symbol = Symbol("deserialize_with");
 pub const OFFSET_BASE: Symbol = Symbol("offset_base");
 pub const EMBED: Symbol = Symbol("embed");
-pub const SERDE: Symbol = Symbol("serde");
+pub const OTSPEC: Symbol = Symbol("otspec");
 pub const SERIALIZE_WITH: Symbol = Symbol("serialize_with");
 pub const SKIP_DESERIALIZING: Symbol = Symbol("skip_deserializing");
 pub const WITH: Symbol = Symbol("with");

--- a/crates/otspec_macros/src/lib.rs
+++ b/crates/otspec_macros/src/lib.rs
@@ -27,7 +27,7 @@ fn to_compile_errors(errors: Vec<syn::Error>) -> proc_macro2::TokenStream {
     quote!(#(#compile_errors)*)
 }
 
-#[proc_macro_derive(Serialize, attributes(serde))]
+#[proc_macro_derive(Serialize, attributes(otspec))]
 pub fn derive_serialize(input: TokenStream) -> TokenStream {
     let mut input = parse_macro_input!(input as DeriveInput);
     ser::expand_derive_serialize(&mut input)
@@ -35,7 +35,7 @@ pub fn derive_serialize(input: TokenStream) -> TokenStream {
         .into()
 }
 
-#[proc_macro_derive(Deserialize, attributes(serde))]
+#[proc_macro_derive(Deserialize, attributes(otspec))]
 pub fn derive_deserialize(input: TokenStream) -> TokenStream {
     let mut input = parse_macro_input!(input as DeriveInput);
     de::expand_derive_deserialize(&mut input)

--- a/src/GPOS.rs
+++ b/src/GPOS.rs
@@ -90,8 +90,8 @@ impl Deserialize for GPOS {
     fn from_bytes(c: &mut ReaderContext) -> Result<Self, DeserializationError> {
         #[derive(Debug, Deserialize)]
         struct RawLookupList {
-            #[serde(offset_base)]
-            #[serde(with = "Counted")]
+            #[otspec(offset_base)]
+            #[otspec(with = "Counted")]
             pub lookups: VecOffset16<Lookup<Positioning>>,
         }
 

--- a/src/GSUB.rs
+++ b/src/GSUB.rs
@@ -91,8 +91,8 @@ impl Deserialize for GSUB {
 
         #[derive(Debug, Deserialize)]
         struct RawLookupList {
-            #[serde(offset_base)]
-            #[serde(with = "Counted")]
+            #[otspec(offset_base)]
+            #[otspec(with = "Counted")]
             lookups: VecOffset16<Lookup<Substitution>>,
         }
 

--- a/src/layout/contextual.rs
+++ b/src/layout/contextual.rs
@@ -124,13 +124,13 @@ impl Deserialize for SequenceContextFormat3 {
 #[allow(missing_docs, non_snake_case)]
 #[derive(Debug, Serialize, Clone, PartialEq)]
 pub struct ChainedSequenceRule {
-    #[serde(with = "Counted")]
+    #[otspec(with = "Counted")]
     pub backtrackSequence: Vec<uint16>,
     pub inputGlyphCount: uint16,
     pub inputSequence: Vec<uint16>,
-    #[serde(with = "Counted")]
+    #[otspec(with = "Counted")]
     pub lookaheadSequence: Vec<uint16>,
-    #[serde(with = "Counted")]
+    #[otspec(with = "Counted")]
     pub seqLookupRecords: Vec<SequenceLookupRecord>,
 }
 

--- a/src/layout/gpos1.rs
+++ b/src/layout/gpos1.rs
@@ -30,22 +30,22 @@ facilitate serialization.
 #[derive(Debug, PartialEq, Clone, Serialize)]
 #[allow(missing_docs, non_snake_case, non_camel_case_types)]
 pub struct SinglePosFormat1 {
-    #[serde(offset_base)]
+    #[otspec(offset_base)]
     pub posFormat: uint16,
     pub coverage: Offset16<Coverage>,
     pub valueFormat: ValueRecordFlags,
-    #[serde(embed)]
+    #[otspec(embed)]
     pub valueRecord: ValueRecord,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize)]
 #[allow(missing_docs, non_snake_case, non_camel_case_types)]
 pub struct SinglePosFormat2 {
-    #[serde(offset_base)]
+    #[otspec(offset_base)]
     pub posFormat: uint16,
     pub coverage: Offset16<Coverage>,
     pub valueFormat: ValueRecordFlags,
-    #[serde(with = "Counted")]
+    #[otspec(with = "Counted")]
     pub valueRecords: Vec<ValueRecord>,
 }
 

--- a/src/layout/gpos2.rs
+++ b/src/layout/gpos2.rs
@@ -16,20 +16,20 @@ use crate::format_switching_lookup;
 #[derive(Debug, PartialEq, Clone, Serialize)]
 #[allow(missing_docs, non_snake_case, non_camel_case_types)]
 pub struct PairPosFormat1 {
-    #[serde(offset_base)]
+    #[otspec(offset_base)]
     pub posFormat: uint16,
     pub coverage: Offset16<Coverage>,
     pub valueFormat1: ValueRecordFlags,
     pub valueFormat2: ValueRecordFlags,
-    #[serde(with = "Counted")]
+    #[otspec(with = "Counted")]
     pub pairSets: VecOffset16<PairSet>,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize)]
 #[allow(missing_docs, non_snake_case, non_camel_case_types)]
 pub struct PairSet {
-    #[serde(offset_base)]
-    #[serde(with = "Counted")]
+    #[otspec(offset_base)]
+    #[otspec(with = "Counted")]
     pub pairValueRecords: Vec<PairValueRecord>,
 }
 
@@ -37,16 +37,16 @@ pub struct PairSet {
 #[allow(missing_docs, non_snake_case, non_camel_case_types)]
 pub struct PairValueRecord {
     pub secondGlyph: uint16,
-    #[serde(embed)]
+    #[otspec(embed)]
     pub valueRecord1: ValueRecord,
-    #[serde(embed)]
+    #[otspec(embed)]
     pub valueRecord2: ValueRecord,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize)]
 #[allow(missing_docs, non_snake_case, non_camel_case_types)]
 pub struct PairPosFormat2 {
-    #[serde(offset_base)]
+    #[otspec(offset_base)]
     pub posFormat: uint16,
     pub coverage: Offset16<Coverage>,
     pub valueFormat1: ValueRecordFlags,
@@ -67,9 +67,9 @@ pub struct Class1Record {
 #[derive(Debug, PartialEq, Clone, Serialize)]
 #[allow(missing_docs, non_snake_case, non_camel_case_types)]
 pub struct Class2Record {
-    #[serde(embed)]
+    #[otspec(embed)]
     pub valueRecord1: ValueRecord,
-    #[serde(embed)]
+    #[otspec(embed)]
     pub valueRecord2: ValueRecord,
 }
 

--- a/src/layout/valuerecord.rs
+++ b/src/layout/valuerecord.rs
@@ -14,7 +14,7 @@ use crate::utils::is_all_the_same;
 // have serialized elsewhere.
 #[derive(Debug, Clone, PartialEq, Serialize, Default)]
 #[allow(missing_docs, non_snake_case, non_camel_case_types)]
-#[serde(embedded)]
+#[otspec(embedded)]
 pub struct ValueRecord {
     // This is *not* an offset base!!!
     pub xPlacement: Option<int16>,

--- a/src/maxp.rs
+++ b/src/maxp.rs
@@ -51,7 +51,7 @@ impl Serialize for MaxpVariant {
 #[derive(Debug, Serialize, PartialEq)]
 pub struct maxp {
     /// The version number as a fixed U16F16 value (for ease of serialization)
-    #[serde(with = "Version16Dot16")]
+    #[otspec(with = "Version16Dot16")]
     pub version: U16F16,
     /// Either a maxp 0.5 table or a maxp 1.0 table
     pub table: MaxpVariant,


### PR DESCRIPTION
This started out with trying to fix a warning about an invalid
macro attribute, and then in the process I ended up confused
that we were using 'serde' as our macro attribute keyword.