### PR TITLE
Fixup tag! macro export situation

### DIFF
--- a/crates/designspace/src/lib.rs
+++ b/crates/designspace/src/lib.rs
@@ -7,14 +7,14 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fs::File;
 use std::path::Path;
-extern crate fonttools;
+
 use fonttools::avar::{avar, SegmentMap};
 use fonttools::font::{Font, Table};
 use fonttools::fvar::{fvar, InstanceRecord, VariationAxisRecord};
 use fonttools::name::NameRecord;
 use fonttools::otvar::Location as OTVarLocation;
 use fonttools::otvar::{NormalizedLocation, VariationModel};
-use otspec::types::{tag, Tag};
+use fonttools::{tag, types::Tag};
 pub use serde_xml_rs::from_reader;
 
 #[cfg(feature = "norad")]

--- a/crates/fonttools-cli/src/bin/fontcrunch.rs
+++ b/crates/fonttools-cli/src/bin/fontcrunch.rs
@@ -10,7 +10,7 @@ use fonttools::glyf::{
     },
     Glyph,
 };
-use fonttools::{font::Table, types::tag};
+use fonttools::{font::Table, tag};
 use fonttools_cli::{open_font, read_args, save_font};
 use indicatif::{ParallelProgressIterator, ProgressBar, ProgressStyle};
 use kurbo::{BezPath, PathSeg, Point, QuadBez};

--- a/crates/fonttools-cli/src/bin/ttf-add-minimal-dsig.rs
+++ b/crates/fonttools-cli/src/bin/ttf-add-minimal-dsig.rs
@@ -10,7 +10,7 @@ fn main() {
 
     if !infont.tables.contains_key(b"DSIG") {
         infont.tables.insert(
-            fonttools::types::tag!("DSIG"),
+            fonttools::tag!("DSIG"),
             Table::Unknown(vec![0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00]),
         );
     }

--- a/crates/fonttools-cli/src/bin/ttf-edit-math.rs
+++ b/crates/fonttools-cli/src/bin/ttf-edit-math.rs
@@ -1,7 +1,7 @@
 use clap::{App, Arg};
 use fonttools::font::Table;
-use fonttools::types::*;
 use fonttools::MATH::*;
+use fonttools::{tag, types::*};
 use fonttools_cli::open_font;
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};

--- a/crates/fonttools-cli/src/bin/ttf-fix-non-hinted.rs
+++ b/crates/fonttools-cli/src/bin/ttf-fix-non-hinted.rs
@@ -5,7 +5,7 @@ Improve the appearance of an unhinted font on Win platforms by:
     - Add a new prep table which is optimized for unhinted fonts.
 */
 use fonttools::gasp;
-use fonttools::{font::Table, types::tag};
+use fonttools::{font::Table, tag};
 use fonttools_cli::{open_font, read_args, save_font};
 
 fn main() {

--- a/crates/fonttools-cli/src/bin/ttf-flatten-components.rs
+++ b/crates/fonttools-cli/src/bin/ttf-flatten-components.rs
@@ -1,4 +1,4 @@
-use fonttools::{font::Table, types::tag};
+use fonttools::{font::Table, tag};
 use fonttools_cli::{open_font, read_args, save_font};
 
 fn main() {

--- a/crates/fonttools-cli/src/bin/ttf-optimize-gvar.rs
+++ b/crates/fonttools-cli/src/bin/ttf-optimize-gvar.rs
@@ -1,5 +1,5 @@
 use fonttools::font::Table;
-use fonttools::{glyf, gvar, types::tag};
+use fonttools::{glyf, gvar, tag};
 use fonttools_cli::{open_font, read_args, save_font};
 
 fn main() {

--- a/crates/fonttools-cli/src/bin/ttf-remove-overlap.rs
+++ b/crates/fonttools-cli/src/bin/ttf-remove-overlap.rs
@@ -1,5 +1,5 @@
 use fonttools::glyf::{Glyph, Point};
-use fonttools::{font::Table, types::tag};
+use fonttools::{font::Table, tag};
 use fonttools_cli::{open_font, read_args, save_font};
 
 use skia_safe::{simplify, Path};

--- a/crates/fonttools-cli/src/bin/ttf-rename-glyphs.rs
+++ b/crates/fonttools-cli/src/bin/ttf-rename-glyphs.rs
@@ -1,5 +1,5 @@
 use clap::{App, Arg};
-use fonttools::{font::Table, types::tag};
+use fonttools::{font::Table, tag};
 use fonttools_cli::{open_font, save_font};
 use itertools::Itertools;
 use std::collections::{BTreeMap, HashSet};

--- a/crates/otspec/examples/ttf-dump-graph.rs
+++ b/crates/otspec/examples/ttf-dump-graph.rs
@@ -1,7 +1,8 @@
 use clap::{App, Arg};
 use fonttools::font::{Font, Table};
+use fonttools::tag;
 use fonttools::MATH::MATHinternal;
-use otspec::types::{tag, Offset16, OffsetMarkerTrait};
+use otspec::types::{Offset16, OffsetMarkerTrait};
 use petgraph::dot::{Config, Dot};
 use petgraph::graph::{Graph, NodeIndex};
 

--- a/crates/otspec/src/lib.rs
+++ b/crates/otspec/src/lib.rs
@@ -3,7 +3,7 @@
 extern crate shrinkwraprs;
 
 // necessary for us to use macros defined in otspec_macros
-extern crate self as otspec;
+extern crate self as _tag_macro_crate;
 
 use crate::types::*;
 use std::convert::TryInto;
@@ -339,7 +339,7 @@ mod tests {
 
     #[test]
     fn ser_tag() {
-        let t = tag!("GSUB");
+        let t = Tag::from_raw("GSUB").unwrap();
         let mut out = vec![];
         out.put(t).unwrap();
         assert_eq!(out, [0x47, 0x53, 0x55, 0x42]);
@@ -349,7 +349,7 @@ mod tests {
     fn de_tag() {
         let mut rc = ReaderContext::new(vec![0x47, 0x53, 0x55, 0x42]);
         let t: Tag = rc.de().unwrap();
-        assert_eq!(t, tag!("GSUB"));
+        assert_eq!(t.as_str(), "GSUB");
     }
 
     // use otspec_macros::{Deserialize, Serialize};

--- a/crates/otspec/src/tag.rs
+++ b/crates/otspec/src/tag.rs
@@ -15,8 +15,8 @@ pub struct Tag([u8; 4]);
 impl Tag {
     /// Attempt to create a `Tag` from raw bytes.
     ///
-    /// If the bytes are known at compile time, you should prefer the
-    /// [`tag`][`tag!`] macro.
+    /// If the bytes are known at compile time, and you are using the `fonttools`
+    /// crate, you should prefer the `tag!` macro.
     ///
     /// The argument may be a slice of bytes, a `&str`, or any other type that
     /// impls `AsRef<[u8]>`.

--- a/crates/otspec/src/types.rs
+++ b/crates/otspec/src/types.rs
@@ -24,7 +24,7 @@ pub type GlyphID = u16;
 #[allow(non_camel_case_types)]
 pub struct uint24(u32);
 
-pub use super::tag::{tag, InvalidTag, Tag};
+pub use super::tag::{InvalidTag, Tag};
 
 impl Serialize for uint24 {
     fn to_bytes(&self, data: &mut Vec<u8>) -> Result<(), SerializationError> {

--- a/crates/otspec_macros/src/tag.rs
+++ b/crates/otspec_macros/src/tag.rs
@@ -24,7 +24,7 @@ fn expand_tag_impl(item: TokenStream) -> Result<TokenStream, SyntaxError> {
     let padding = 4 - input.len();
     let padding = &"    "[..padding];
     let tag_lit = format!(
-        "unsafe {{ otspec::types::Tag::from_raw_unchecked(*b\"{}{}\") }}",
+        "unsafe {{ fonttools::types::Tag::from_raw_unchecked(*b\"{}{}\") }}",
         input, padding
     );
     Ok(tag_lit.parse().unwrap())

--- a/src/GSUB.rs
+++ b/src/GSUB.rs
@@ -258,6 +258,7 @@ impl Serialize for GSUB {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tag;
     use pretty_assertions::assert_eq;
     use std::collections::BTreeMap;
     use std::iter::FromIterator;

--- a/src/STAT.rs
+++ b/src/STAT.rs
@@ -385,7 +385,7 @@ impl AxisValue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::btreemap;
+    use crate::{btreemap, tag};
     use pretty_assertions::assert_eq;
     use std::iter::FromIterator;
     #[test]

--- a/src/font.rs
+++ b/src/font.rs
@@ -8,6 +8,7 @@ use crate::maxp::maxp;
 use crate::name::name;
 use crate::os2::os2;
 use crate::post::post;
+use crate::tag;
 use crate::GDEF::GDEF;
 use crate::GPOS::GPOS;
 use crate::GSUB::GSUB;
@@ -650,11 +651,9 @@ mod tests {
 
     use crate::head::head;
     use crate::hhea::hhea;
-    use crate::{font, maxp};
-    use otspec::types::U16F16;
-
+    use crate::{font, maxp, tag};
     use otspec::ser;
-    use otspec::types::*;
+    use otspec::types::U16F16;
 
     #[test]
     fn test_checksum() {

--- a/src/fvar.rs
+++ b/src/fvar.rs
@@ -144,9 +144,10 @@ impl Serialize for fvar {
 
 #[cfg(test)]
 mod tests {
-    use crate::fvar;
-    use crate::fvar::InstanceRecord;
-    use otspec::types::tag;
+    use crate::{
+        fvar::{self, InstanceRecord},
+        tag,
+    };
 
     #[test]
     fn fvar_de() {

--- a/src/glyf.rs
+++ b/src/glyf.rs
@@ -196,10 +196,11 @@ impl glyf {
 
 #[cfg(test)]
 mod tests {
-    use crate::font;
-    use crate::glyf;
-    use crate::glyf::ComponentFlags;
-    use crate::glyf::Point;
+    use crate::{
+        font,
+        glyf::{self, ComponentFlags, Point},
+        tag,
+    };
 
     #[test]
     fn glyf_de() {
@@ -378,7 +379,7 @@ mod tests {
         let mut deserialized: font::Font = otspec::de::from_bytes(&binary_font).unwrap();
         deserialized.fully_deserialize();
         let glyf = deserialized
-            .get_table(otspec::types::tag!("glyf"))
+            .get_table(tag!("glyf"))
             .unwrap()
             .unwrap()
             .glyf_unchecked();

--- a/src/layout/common.rs
+++ b/src/layout/common.rs
@@ -376,6 +376,7 @@ impl Serialize for LookupListOutgoing {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tag;
     use otspec::offsetmanager::OffsetManager;
     use std::iter::FromIterator;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,9 @@
 //! # // we need an explicit main fn to use macros:
 //! # #[macro_use] extern crate otspec;
 //! # fn main() {
+//! use fonttools::tag;
 //! use fonttools::font::{self, Font, Table};
 //! use fonttools::name::{name, NameRecord, NameRecordID};
-//! use otspec::types::tag;
 //!
 //! // Load a font (tables are lazy-loaded)
 //! let mut myfont = Font::load("Test.otf").expect("Could not load font");
@@ -87,3 +87,7 @@ pub mod post;
 pub mod utils;
 
 pub use otspec::types;
+pub use otspec_macros::tag;
+
+// lets us use the tag! macro from otspec_macros within this crate
+extern crate self as fonttools;

--- a/src/otvar/instancer.rs
+++ b/src/otvar/instancer.rs
@@ -1,15 +1,11 @@
 #![allow(missing_docs)]
-use crate::avar;
-use crate::avar::SegmentMap;
-use crate::font::Font;
-use crate::font::Table;
+use crate::avar::{self, SegmentMap};
+use crate::font::{Font, Table};
 use crate::fvar;
 use crate::glyf;
-use crate::gvar;
-use crate::gvar::{Coords, DeltaSet, GlyphVariationData};
+use crate::gvar::{self, Coords, DeltaSet, GlyphVariationData};
 use crate::otvar::support_scalar;
-use crate::types::Tag;
-use otspec::types::*;
+use crate::{tag, types::*};
 use std::collections::BTreeMap;
 
 type Location = BTreeMap<Tag, f32>;

--- a/src/otvar/locations.rs
+++ b/src/otvar/locations.rs
@@ -320,9 +320,8 @@ impl VariationModel {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::btreemap;
+    use crate::{btreemap, tag};
     use assert_approx_eq::assert_approx_eq;
-    use otspec::types::*;
     use std::iter::FromIterator;
 
     #[test]


### PR DESCRIPTION
The tag! macro generates code that looks approximately like:
`crate::types::Tag::unsafe_constructor(input_bytes)`. The tricky part
here is the 'crate' bit. What should go here?

The problem has to do with where the macro is exported. Currently it is
exported from both the `otspec` and the `fonttools` crates. This creates
a problem: if the macro generates `otspec::types::Tag(..)` then it won't
compile when used from `fonttools` if `otspec` is not in scope; and if
it generates `fonttools::types::Tag(..)` then it won't work when used
from otspec if fonttools is not in scope.

I've gone with a simple solution, which is to *only* export tag! from
fonttools, and to generate 'fonttools::types::Tag(..)'. There are fancier
solutions available (such as https://crates.io/crates/proc-macro-crate) that
we can turn to if this ends up being a problem, but I do not expect in practice
that many folks are going to use otspec outside of fonttools.