### PR TITLE
Add TAG constant to each table module

### DIFF
--- a/src/tables/GDEF.rs
+++ b/src/tables/GDEF.rs
@@ -11,6 +11,9 @@ use otspec::{
 use otspec_macros::tables;
 use std::collections::{BTreeMap, BTreeSet};
 
+/// The 'GDEF' OpenType tag.
+pub const TAG: Tag = crate::tag!("GDEF");
+
 // Having version-specific tables makes it so much easier to keep track of
 // the offset fields
 tables!(

--- a/src/tables/GPOS.rs
+++ b/src/tables/GPOS.rs
@@ -15,6 +15,9 @@ use otspec::{
 use otspec_macros::Deserialize;
 use std::convert::TryInto;
 
+/// The 'GPOS' OpenType tag.
+pub const TAG: Tag = crate::tag!("GPOS");
+
 impl Lookup<Positioning> {
     /// Return the integer GPOS lookup type for this lookup
     pub fn lookup_type(&self) -> u16 {

--- a/src/tables/GSUB.rs
+++ b/src/tables/GSUB.rs
@@ -13,6 +13,9 @@ use otspec::{
 use otspec_macros::Deserialize;
 use std::convert::TryInto;
 
+/// The 'GSUB' OpenType tag.
+pub const TAG: Tag = crate::tag!("GSUB");
+
 impl Lookup<Substitution> {
     /// Return the integer GSUB lookup type for this lookup
     pub fn lookup_type(&self) -> u16 {

--- a/src/tables/MATH.rs
+++ b/src/tables/MATH.rs
@@ -6,6 +6,9 @@ use otspec::{DeserializationError, Deserialize, Deserializer, Serialize, Seriali
 use otspec_macros::{tables, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
+/// The 'MATH' OpenType tag.
+pub const TAG: Tag = crate::tag!("MATH");
+
 tables!(
     MathValueRecord [embedded] {
         FWORD value

--- a/src/tables/STAT.rs
+++ b/src/tables/STAT.rs
@@ -7,6 +7,9 @@ use otspec::{
 use otspec_macros::{tables, Deserialize, Serialize};
 use std::collections::BTreeMap;
 
+/// The 'STAT' OpenType tag.
+pub const TAG: Tag = crate::tag!("STAT");
+
 tables!(STATcore {
     uint16 majorVersion
     uint16 minorVersion

--- a/src/tables/avar.rs
+++ b/src/tables/avar.rs
@@ -2,6 +2,9 @@ use otspec::types::*;
 use otspec::Deserializer;
 use otspec_macros::tables;
 
+/// The 'avar' OpenType tag.
+pub const TAG: Tag = crate::tag!("avar");
+
 tables!(
     AxisValueMap {
         F2DOT14 fromCoordinate

--- a/src/tables/cmap.rs
+++ b/src/tables/cmap.rs
@@ -9,6 +9,9 @@ use std::collections::{BTreeMap, HashSet};
 use std::convert::TryInto;
 use std::hash::{Hash, Hasher};
 
+/// The 'cmap' OpenType tag.
+pub const TAG: Tag = crate::tag!("cmap");
+
 tables!(
 
 EncodingRecord {

--- a/src/tables/fvar.rs
+++ b/src/tables/fvar.rs
@@ -5,6 +5,9 @@ use otspec::{
 };
 use otspec_macros::tables;
 
+/// The 'fvar' OpenType tag.
+pub const TAG: Tag = crate::tag!("fvar");
+
 tables!(
     fvarcore {
         uint16 majorVersion
@@ -144,7 +147,7 @@ impl Serialize for fvar {
 
 #[cfg(test)]
 mod tests {
-    use crate::tables::fvar::{self, InstanceRecord};
+    use crate::tables::fvar::InstanceRecord;
     use crate::tag;
 
     #[test]

--- a/src/tables/gasp.rs
+++ b/src/tables/gasp.rs
@@ -3,6 +3,9 @@ use otspec::types::*;
 use otspec::Deserializer;
 use otspec_macros::{tables, Deserialize, Serialize};
 
+/// The 'gasp' OpenType tag.
+pub const TAG: Tag = crate::tag!("gasp");
+
 tables!(
 GaspRecord {
     uint16 rangeMaxPPEM

--- a/src/tables/glyf.rs
+++ b/src/tables/glyf.rs
@@ -14,6 +14,9 @@ pub use component::{Component, ComponentFlags};
 pub use glyph::Glyph;
 pub use point::Point;
 
+/// The 'glyf' OpenType tag.
+pub const TAG: otspec::types::Tag = crate::tag!("glyf");
+
 /// The glyf table
 #[allow(non_camel_case_types)]
 #[derive(Debug, PartialEq, Clone)]

--- a/src/tables/gvar.rs
+++ b/src/tables/gvar.rs
@@ -12,6 +12,9 @@ use std::convert::TryInto;
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
 
+/// The 'gvar' OpenType tag.
+pub const TAG: Tag = crate::tag!("gvar");
+
 pub(crate) type Coords = Vec<(int16, int16)>;
 pub(crate) type CoordsAndEndsVec = Vec<(Coords, Vec<usize>)>;
 

--- a/src/tables/head.rs
+++ b/src/tables/head.rs
@@ -2,6 +2,9 @@ use otspec::types::*;
 use otspec::Deserializer;
 use otspec_macros::tables;
 
+/// The 'head' OpenType tag.
+pub const TAG: Tag = crate::tag!("head");
+
 tables!(head {
     uint16 majorVersion
     uint16 minorVersion

--- a/src/tables/hhea.rs
+++ b/src/tables/hhea.rs
@@ -2,6 +2,9 @@ use otspec::types::*;
 use otspec::Deserializer;
 use otspec_macros::tables;
 
+/// The 'hhea' OpenType tag.
+pub const TAG: Tag = crate::tag!("hhea");
+
 tables!(hhea {
     uint16 majorVersion
     uint16 minorVersion

--- a/src/tables/hmtx.rs
+++ b/src/tables/hmtx.rs
@@ -2,6 +2,9 @@ use otspec::types::*;
 use otspec::{DeserializationError, Deserializer, ReaderContext, Serialize};
 use otspec_macros::{Deserialize, Serialize};
 
+/// The 'hmtx' OpenType tag.
+pub const TAG: Tag = crate::tag!("hmtx");
+
 /// A single horizontal metric
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[allow(non_snake_case)]

--- a/src/tables/loca.rs
+++ b/src/tables/loca.rs
@@ -1,5 +1,8 @@
 use otspec::{DeserializationError, Deserializer, ReaderContext, Serialize};
 
+/// The 'loca' OpenType tag.
+pub const TAG: otspec::types::Tag = crate::tag!("loca");
+
 /// A [`loca`] table.
 ///
 /// [`loca`]: https://docs.microsoft.com/en-us/typography/opentype/spec/loca

--- a/src/tables/maxp.rs
+++ b/src/tables/maxp.rs
@@ -2,6 +2,9 @@ use otspec::types::*;
 use otspec::{DeserializationError, Deserialize, Deserializer, ReaderContext, Serialize};
 use otspec_macros::{tables, Serialize};
 
+/// The 'maxp' OpenType tag.
+pub const TAG: Tag = crate::tag!("maxp");
+
 tables!(
 maxp05 {
     uint16  numGlyphs

--- a/src/tables/name.rs
+++ b/src/tables/name.rs
@@ -8,6 +8,9 @@ use otspec::{
 };
 use otspec_macros::tables;
 
+/// The 'name' OpenType tag.
+pub const TAG: Tag = crate::tag!("name");
+
 fn get_encoding(platform_id: u16, encoding_id: u16) -> EncodingRef {
     if platform_id == 0 {
         return UTF_16BE;

--- a/src/tables/os2.rs
+++ b/src/tables/os2.rs
@@ -6,6 +6,9 @@ use otspec::{
 use otspec_macros::tables;
 use std::collections::{BTreeMap, HashSet};
 
+/// The 'OS/2' OpenType tag.
+pub const TAG: Tag = crate::tag!("OS/2");
+
 tables!(
     Panose {
         u8 panose0

--- a/src/tables/post.rs
+++ b/src/tables/post.rs
@@ -4,6 +4,9 @@ use otspec::{
 };
 use otspec_macros::tables;
 
+/// The 'post' OpenType tag.
+pub const TAG: Tag = crate::tag!("post");
+
 /// The list of 258 standard Macintosh glyph names.
 /// Names not in this list will be stored separately in the post table if
 /// version==2


### PR DESCRIPTION
This means you can do `tables::GPOS::TAG` instead of `tag!("GPOS")`, as needed. I think this makes sense, but I'm not married to it...