### PR TITLE
New table access API.

### DIFF
--- a/crates/fonttools-cli/src/bin/ttf-add-minimal-dsig.rs
+++ b/crates/fonttools-cli/src/bin/ttf-add-minimal-dsig.rs
@@ -1,4 +1,4 @@
-use fonttools::font::Table;
+use fonttools::tag;
 use fonttools_cli::{open_font, read_args, save_font};
 
 fn main() {
@@ -8,10 +8,10 @@ fn main() {
     );
     let mut infont = open_font(&matches);
 
-    if !infont.tables.contains_key(b"DSIG") {
-        infont.tables.insert(
-            fonttools::tag!("DSIG"),
-            Table::Unknown(vec![0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00]),
+    if !infont.tables.contains(&tag!("DSIG")) {
+        infont.tables.insert_raw(
+            tag!("DSIG"),
+            vec![0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00],
         );
     }
     save_font(infont, &matches);

--- a/crates/fonttools-cli/src/bin/ttf-edit-math.rs
+++ b/crates/fonttools-cli/src/bin/ttf-edit-math.rs
@@ -1,5 +1,4 @@
 use clap::{App, Arg};
-use fonttools::font::Table;
 use fonttools::tables::MATH::*;
 use fonttools::tag;
 use fonttools::types::*;
@@ -285,23 +284,16 @@ fn main() {
         .get_matches();
     let mut infont = open_font(&matches);
 
-    let glyph_names = if let Table::Post(post) = infont
-        .get_table(tag!("post"))
-        .expect("Error reading post table")
-        .expect("No post table found")
-    {
-        post.glyphnames.clone().unwrap_or_else(std::vec::Vec::new)
-    } else {
-        vec![]
-    };
+    let post = infont.tables.post().unwrap().unwrap();
+    let glyph_names = post.glyphnames.clone().unwrap_or_else(std::vec::Vec::new);
 
     if matches.value_of("mode").unwrap() == "dump" {
         let math = infont
-            .get_table(tag!("MATH"))
+            .tables
+            .MATH()
             .expect("No math table")
-            .expect("Couldn't parse MATH table")
-            .MATH_unchecked();
-        let simplified: MathEvenEasier = simplify(math, glyph_names);
+            .expect("Couldn't parse MATH table");
+        let simplified: MathEvenEasier = simplify(&math, glyph_names);
         serde_json::to_writer_pretty(io::stdout(), &simplified).expect("Oops");
     }
     // save_font(infont, &matches);

--- a/crates/fonttools-cli/src/bin/ttf-fix-non-hinted.rs
+++ b/crates/fonttools-cli/src/bin/ttf-fix-non-hinted.rs
@@ -4,7 +4,6 @@ Improve the appearance of an unhinted font on Win platforms by:
       for all sizes.
     - Add a new prep table which is optimized for unhinted fonts.
 */
-use fonttools::font::Table;
 use fonttools::tables::gasp;
 use fonttools::tag;
 use fonttools_cli::{open_font, read_args, save_font};
@@ -16,7 +15,7 @@ fn main() {
     );
     let mut infont = open_font(&matches);
 
-    if !infont.tables.contains_key(&tag!("gasp")) {
+    if !infont.tables.contains(&tag!("gasp")) {
         let gasp_table = gasp::gasp {
             version: 1,
             gaspRanges: vec![gasp::GaspRecord {
@@ -30,9 +29,10 @@ fn main() {
                     | gasp::RangeGaspBehaviorFlags::GASP_SYMMETRIC_GRIDFIT,
             }],
         };
-        infont.tables.insert(tag!("gasp"), Table::Gasp(gasp_table));
+        infont.tables.insert(gasp_table);
     }
-    let prep_table = Table::Unknown(vec![0xb8, 0x01, 0xff, 0x85, 0xb0, 0x04, 0x8d]);
-    infont.tables.insert(tag!("prep"), prep_table);
+    infont
+        .tables
+        .insert_raw(tag!("prep"), vec![0xb8, 0x01, 0xff, 0x85, 0xb0, 0x04, 0x8d]);
     save_font(infont, &matches);
 }

--- a/crates/fonttools-cli/src/bin/ttf-flatten-components.rs
+++ b/crates/fonttools-cli/src/bin/ttf-flatten-components.rs
@@ -1,4 +1,3 @@
-use fonttools::{font::Table, tag};
 use fonttools_cli::{open_font, read_args, save_font};
 
 fn main() {
@@ -9,12 +8,12 @@ fn main() {
 
     let mut infont = open_font(&matches);
 
-    if let Table::Glyf(glyf) = infont
-        .get_table(tag!("glyf"))
+    let mut glyf = infont
+        .tables
+        .glyf()
         .expect("Error reading glyf table")
-        .expect("No glyf table found")
-    {
-        glyf.flatten_components()
-    }
+        .expect("No glyf table found");
+    glyf.flatten_components();
+    infont.tables.insert(glyf);
     save_font(infont, &matches);
 }

--- a/crates/fonttools-cli/src/bin/ttf-instantiate.rs
+++ b/crates/fonttools-cli/src/bin/ttf-instantiate.rs
@@ -2,6 +2,7 @@ use clap::{App, Arg};
 use fonttools::otvar::instancer::{
     instantiate_variable_font, AxisRange, UserAxisLimit, UserAxisLimits,
 };
+use fonttools::tag;
 use fonttools::types::*;
 use fonttools_cli::open_font;
 use regex::Regex;
@@ -45,7 +46,7 @@ fn main() {
     }
 
     let mut infont = open_font(&matches);
-    if !infont.tables.contains_key(b"fvar") {
+    if !infont.tables.contains(&tag!("fvar")) {
         println!("This isn't a variable font");
         return;
     }

--- a/crates/fonttools-cli/src/bin/ttf-remove-overlap.rs
+++ b/crates/fonttools-cli/src/bin/ttf-remove-overlap.rs
@@ -1,4 +1,3 @@
-use fonttools::font::Table;
 use fonttools::tables::glyf::{Glyph, Point};
 use fonttools::tag;
 use fonttools_cli::{open_font, read_args, save_font};
@@ -86,11 +85,11 @@ fn skia_to_glyf(p: Path) -> Vec<Vec<Point>> {
 fn main() {
     let matches = read_args("ttf-remove-overlap", "Removes overlap from TTF files");
     let mut infont = open_font(&matches);
-    if let Table::Glyf(glyf) = infont.get_table(tag!("glyf")).unwrap().unwrap() {
-        for glyph in glyf.glyphs.iter_mut() {
-            remove_overlap(glyph);
-        }
-        glyf.recalc_bounds();
+    let mut glyf = infont.tables.glyf().unwrap().unwrap();
+    for glyph in glyf.glyphs.iter_mut() {
+        remove_overlap(glyph);
     }
+    glyf.recalc_bounds();
+    infont.tables.insert(glyf);
     save_font(infont, &matches);
 }

--- a/crates/otspec/src/lib.rs
+++ b/crates/otspec/src/lib.rs
@@ -17,7 +17,7 @@ pub mod types;
 
 #[derive(Debug)]
 pub struct SerializationError(pub String);
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct DeserializationError(pub String);
 
 pub struct ReaderContext {
@@ -212,6 +212,21 @@ where
 }
 
 impl<T> Serialize for Vec<T>
+where
+    T: Serialize,
+{
+    fn to_bytes(&self, data: &mut Vec<u8>) -> Result<(), SerializationError> {
+        self.as_slice().to_bytes(data)
+    }
+    fn ot_binary_size(&self) -> usize {
+        self.as_slice().ot_binary_size()
+    }
+    fn offset_fields(&self) -> Vec<&dyn types::OffsetMarkerTrait> {
+        self.as_slice().offset_fields()
+    }
+}
+
+impl<T> Serialize for [T]
 where
     T: Serialize,
 {

--- a/src/layout/common.rs
+++ b/src/layout/common.rs
@@ -131,6 +131,7 @@ impl Default for LookupFlags {
         LookupFlags::empty()
     }
 }
+
 /// A script list
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct ScriptList {
@@ -275,7 +276,7 @@ pub struct Lookup<T> {
 
 // GPOS and GSUB tables
 
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Debug, PartialEq, Clone)]
 #[allow(clippy::upper_case_acronyms)]
 /// The Glyph Positioning table
 pub struct GPOSGSUB<T> {
@@ -370,6 +371,16 @@ impl Serialize for LookupListOutgoing {
         let mut v: Vec<&dyn OffsetMarkerTrait> = Vec::new();
         v.extend(self.lookups.offset_fields());
         v
+    }
+}
+
+impl<T> Default for GPOSGSUB<T> {
+    fn default() -> Self {
+        Self {
+            lookups: Default::default(),
+            scripts: Default::default(),
+            features: Default::default(),
+        }
     }
 }
 

--- a/src/layout/coverage.rs
+++ b/src/layout/coverage.rs
@@ -1,10 +1,7 @@
 use otspec::types::*;
-use otspec::DeserializationError;
-use otspec::Deserialize;
-use otspec::Deserializer;
-use otspec::ReaderContext;
-use otspec::SerializationError;
-use otspec::Serialize;
+use otspec::{
+    DeserializationError, Deserialize, Deserializer, ReaderContext, SerializationError, Serialize,
+};
 
 use otspec_macros::tables;
 
@@ -22,7 +19,7 @@ tables!(
     }
 );
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Default)]
 /// A coverage table.
 ///
 /// OpenType lookups store information about which glyphs are affected by the

--- a/src/layout/gpos4.rs
+++ b/src/layout/gpos4.rs
@@ -156,14 +156,22 @@ impl From<&MarkBasePos> for MarkBasePosFormat1 {
                 })
                 .collect(),
         });
-        let mut base_records: Vec<BaseRecord> = vec![];
-        for base in lookup.bases.values() {
-            base_records.push(BaseRecord {
+
+        let base_records = lookup
+            .bases
+            .values()
+            .map(|base| BaseRecord {
                 baseAnchors: (0..markClassCount)
-                    .map(|i| Offset16::to(*base.get(&i).unwrap_or(&Anchor::new(0, 0))))
+                    .map(|i| {
+                        base.get(&i)
+                            .copied()
+                            .map(Offset16::to)
+                            .unwrap_or_else(Offset16::to_nothing)
+                    })
                     .collect(),
             })
-        }
+            .collect();
+
         MarkBasePosFormat1 {
             posFormat: 1,
             markCoverage: Offset16::to(Coverage {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,23 +9,24 @@
 //! # // we need an explicit main fn to use macros:
 //! # #[macro_use] extern crate otspec;
 //! # fn main() {
-//! use fonttools::tag;
-//! use fonttools::font::{self, Font, Table};
+//! use fonttools::font::{self, Font};
 //! use fonttools::tables::name::{name, NameRecord, NameRecordID};
 //!
 //! // Load a font (tables are lazy-loaded)
 //! let mut myfont = Font::load("Test.otf").expect("Could not load font");
 //!
 //! // Access an existing table
-//! if let Table::Name(name_table) = myfont.get_table(tag!("name"))
-//!         .expect("Error reading name table")
-//!         .expect("There was no name table") {
+//! let mut name = myfont.tables.name()
+//!    .expect("Error reading name table")
+//!    .expect("There was no name table");
+//!
 //!     // Manipulate the table (table-specific)
-//!         name_table.records.push(NameRecord::windows_unicode(
-//!             NameRecordID::LicenseURL,
-//!             "http://opensource.org/licenses/OFL-1.1"
-//!         ));
-//! }
+//! name.records.push(NameRecord::windows_unicode(
+//!     NameRecordID::LicenseURL,
+//!     "http://opensource.org/licenses/OFL-1.1"
+//! ));
+//!
+//! myfont.tables.insert(name);
 //!
 //! myfont.save("Test-with-OFL.otf").expect("Could not create file");
 //! # }
@@ -41,6 +42,7 @@ pub mod font;
 pub mod layout;
 /// OpenType Variations common tables
 pub mod otvar;
+mod table_store;
 /// OpenType table definitions.
 pub mod tables;
 /// Useful utilities

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ pub mod font;
 pub mod layout;
 /// OpenType Variations common tables
 pub mod otvar;
-mod table_store;
+pub mod table_store;
 /// OpenType table definitions.
 pub mod tables;
 /// Useful utilities

--- a/src/otvar.rs
+++ b/src/otvar.rs
@@ -15,7 +15,7 @@ mod tuplevariationheader;
 /// Tuple Variation Store
 mod tuplevariationstore;
 
-pub mod instancer;
+//pub mod instancer;
 
 pub use itemvariationstore::{ItemVariationData, ItemVariationStore, RegionAxisCoordinates};
 pub use locations::{support_scalar, Location, NormalizedLocation, VariationModel};

--- a/src/otvar.rs
+++ b/src/otvar.rs
@@ -15,7 +15,7 @@ mod tuplevariationheader;
 /// Tuple Variation Store
 mod tuplevariationstore;
 
-//pub mod instancer;
+pub mod instancer;
 
 pub use itemvariationstore::{ItemVariationData, ItemVariationStore, RegionAxisCoordinates};
 pub use locations::{support_scalar, Location, NormalizedLocation, VariationModel};

--- a/src/table_store.rs
+++ b/src/table_store.rs
@@ -1,0 +1,272 @@
+use std::borrow::Borrow;
+use std::{any::Any, cell::RefCell, collections::BTreeMap, rc::Rc};
+
+use otspec::types::{tag, Tag};
+use otspec::{DeserializationError, ReaderContext};
+
+use crate::tables;
+
+/// A lazy loader for the set of OpenType tables in a font.
+#[derive(Debug, Default)]
+pub struct TableSet {
+    tables: BTreeMap<Tag, RefCell<LazyItem>>,
+}
+
+#[derive(Debug)]
+enum LazyItem {
+    Unloaded(Rc<[u8]>),
+    Loaded(Rc<dyn Any>),
+    Error(DeserializationError),
+}
+
+/// An unknown table.
+#[derive(Debug, Clone)]
+pub struct UnknownTable {
+    /// The raw data for this table.
+    pub data: Rc<[u8]>,
+}
+
+impl TableSet {
+    pub fn len(&self) -> usize {
+        self.tables.len()
+    }
+
+    /// Get a table that has already been loaded.
+    ///
+    /// If the table has not been loaded this will return `None`, even if it
+    /// exists.
+    pub fn get_no_load<T: Any>(&self, tag: Tag) -> Option<&T> {
+        self.tables
+            .get(&tag)
+            .and_then(|item| item.borrow().loaded())
+            .map(|t| t.downcast_ref().expect("invalid type in table"))
+    }
+
+    /// Get a table, attempting to load it if necessary.
+    pub fn get<T: Any>(&self, tag: Tag) -> Result<Option<&T>, DeserializationError> {
+        self.load_if_needed(tag)?;
+        Ok(self.get_no_load(tag))
+    }
+
+    /// Returns `true` if the provided tag is a table in this `TableSet`.
+    pub fn contains<Q>(&self, table: &Q) -> bool
+    where
+        Tag: Borrow<Q>,
+        Q: Ord,
+    {
+        self.tables.contains_key(table)
+    }
+
+    pub fn remove(&mut self, table: Tag) -> Option<()> {
+        self.tables.remove(&table).map(|_| ())
+    }
+
+    fn load_if_needed(&self, tag: Tag) -> Result<(), DeserializationError> {
+        let item = match self.tables.get(&tag) {
+            Some(item) => item,
+            _ => return Ok(()),
+        };
+
+        let to_load = match *item.borrow() {
+            LazyItem::Unloaded(data) => data.clone(),
+            LazyItem::Error(e) => return Err(e.clone()),
+            LazyItem::Loaded(_) => unreachable!(),
+        };
+
+        let loaded_table = self.deserialize_table(tag, to_load)?;
+        *item.borrow_mut() = LazyItem::Loaded(loaded_table);
+        Ok(())
+    }
+
+    fn deserialize_table(
+        &self,
+        tag: Tag,
+        data: Rc<[u8]>,
+    ) -> Result<Rc<dyn Any>, DeserializationError> {
+        let table: Rc<dyn Any> = match tag.as_bytes() {
+            b"avar" => Rc::new(otspec::de::from_bytes::<tables::avar::avar>(&data)?),
+            b"cmap" => Rc::new(otspec::de::from_bytes::<tables::cmap::cmap>(&data)?),
+            b"fvar" => Rc::new(otspec::de::from_bytes::<tables::fvar::fvar>(&data)?),
+            b"gasp" => Rc::new(otspec::de::from_bytes::<tables::gasp::gasp>(&data)?),
+            b"GDEF" => Rc::new(otspec::de::from_bytes::<tables::GDEF::GDEF>(&data)?),
+            b"GPOS" => Rc::new(otspec::de::from_bytes::<tables::GPOS::GPOS>(&data)?),
+            b"GSUB" => Rc::new(otspec::de::from_bytes::<tables::GSUB::GSUB>(&data)?),
+            b"head" => Rc::new(otspec::de::from_bytes::<tables::head::head>(&data)?),
+            b"hhea" => Rc::new(otspec::de::from_bytes::<tables::hhea::hhea>(&data)?),
+            b"MATH" => Rc::new(otspec::de::from_bytes::<tables::MATH::MATH>(&data)?),
+            b"maxp" => Rc::new(otspec::de::from_bytes::<tables::maxp::maxp>(&data)?),
+            b"name" => Rc::new(otspec::de::from_bytes::<tables::name::name>(&data)?),
+            b"OS/2" => Rc::new(otspec::de::from_bytes::<tables::os2::os2>(&data)?),
+            b"post" => Rc::new(otspec::de::from_bytes::<tables::post::post>(&data)?),
+            b"STAT" => Rc::new(otspec::de::from_bytes::<tables::STAT::STAT>(&data)?),
+            b"hmtx" => {
+                let number_of_hmetrics = self
+                    .get_no_load::<tables::hhea::hhea>(tag!("hhea"))
+                    .map(|hhea| hhea.numberOfHMetrics)
+                    .ok_or_else(|| DeserializationError("deserialize hhea before hmtx".into()))?;
+                Rc::new(tables::hmtx::from_bytes(
+                    &mut ReaderContext::new(data.to_vec()),
+                    number_of_hmetrics,
+                )?)
+            }
+            b"loca" => {
+                let is_32bit = self
+                    .get_no_load::<tables::head::head>(tag!("head"))
+                    .map(|head| head.indexToLocFormat == 1)
+                    .ok_or_else(|| DeserializationError("deserialize head before loca".into()))?;
+                Rc::new(tables::loca::from_bytes(
+                    &mut ReaderContext::new(data.to_vec()),
+                    is_32bit,
+                )?)
+            }
+            b"glyf" => {
+                let loca_offsets = self
+                    .get_no_load::<tables::loca::loca>(tag!("loca"))
+                    .map(|loca| &loca.indices)
+                    .ok_or_else(|| DeserializationError("deserialize loca before glyf".into()))?;
+                Rc::new(tables::glyf::from_bytes(&data, loca_offsets)?)
+            }
+            b"gvar" => {
+                let glyf = self
+                    .get_no_load::<tables::glyf::glyf>(tag!("glyf"))
+                    //.map(|glyf| &loca.indices)
+                    .ok_or_else(|| DeserializationError("deserialize glyf before gvar".into()))?;
+                let coords_and_ends = glyf
+                    .glyphs
+                    .iter()
+                    .map(|g| g.gvar_coords_and_ends())
+                    .collect();
+
+                Rc::new(tables::gvar::from_bytes(&data, coords_and_ends)?)
+            }
+            _ => Rc::new(data.to_owned()),
+        };
+        Ok(table)
+    }
+}
+
+impl LazyItem {
+    fn loaded(&self) -> Option<&dyn Any> {
+        match self {
+            LazyItem::Unloaded(_) => None,
+            LazyItem::Error(_) => None,
+            LazyItem::Loaded(thing) => Some(thing),
+        }
+    }
+
+    fn needs_load(&self) -> bool {
+        matches!(self, LazyItem::Unloaded(_))
+    }
+}
+
+//fn load(&mut self, tag: Tag) -> Result<(), DeserializationError> {
+//let data = match self.unloaded.remove(&tag) {
+//Some(data) => data,
+//None => return Ok(()),
+//};
+
+//let data: Rc<dyn Any> = match tag.as_str() {
+//"avar" => Rc::new(otspec::de::from_bytes::<tables::avar::avar>(&data)?),
+//"cmap" => Rc::new(otspec::de::from_bytes::<tables::cmap::cmap>(&data)?),
+//// other tables here
+//other => Rc::new(data),
+//};
+//self.loaded.insert(tag, data);
+//Ok(())
+//}
+
+//fn load_tables(&mut self, tables: &[Tag]) -> Result<(), DeserializationError> {
+//for tag in tables {
+//self.load(*tag)?;
+//}
+//Ok(())
+//}
+
+//fn needs_to_deserialize(&self, table: Tag) -> bool {
+//self.unloaded.contains_key(&table)
+//}
+
+//fn get_or_deserialize<T: Any>(
+//&mut self,
+//tag: Tag,
+//d: impl FnOnce(&[u8]) -> Result<T, DeserializationError>,
+//) -> Result<Option<Rc<T>, DeserializationError>> {
+
+//}
+
+//fn gpos(&self) -> Option<&crate::GPOS::GPOS> {
+//self.get_typed(GPOS_TAG)
+//}
+
+//fn gpos_mut(&mut self) -> Option<&mut crate::GPOS::GPOS> {
+//self.get_typed_mut(GPOS_TAG)
+//}
+
+//fn get_typed<T: Any>(&self, tag: Tag) -> Option<&T> {
+//assert!(
+// !self.unloaded.borrow().contains_key(&tag),
+//"tables must be loaded before use"
+//);
+//self.loaded
+//.get(&tag)
+//.map(|t| t.downcast_ref().expect("wrong type for tag"))
+//}
+
+//fn get_typed_mut<T: Any>(&mut self, tag: Tag) -> Option<&mut T> {
+//assert!(
+// !self.unloaded.contains_key(&tag),
+//"tables must be loaded before use"
+//);
+//self.loaded
+//.get_mut(&tag)
+//.map(|t| t.downcast_mut().expect("wrong type for tag"))
+//}
+
+//fn other_table(&self, tag: Tag) -> Option<&[u8]> {
+//self.unloaded.get(&tag).map(Vec::as_slice)
+//}
+//}
+
+//#[derive(Debug, Default)]
+//pub struct Tables(BTreeMap<Tag, RefCell<Table>>);
+
+//impl Tables {
+//pub fn len(&self) -> usize {
+//self.0.len()
+//}
+
+//pub fn is_empty(&self) -> bool {
+//self.0.is_empty()
+//}
+
+////pub fn iter(&self) -> impl Iterator<Item = (&Tag, &Table)> {
+////self.0.iter().map(|(a, b)| (a, b.borrow().deref()))
+////}
+
+//pub fn keys(&self) -> impl Iterator<Item = &Tag> {
+//self.0.keys()
+//}
+
+//pub fn contains_key(&self, key: Tag) -> bool {
+//self.0.contains_key(&key)
+//}
+
+//pub fn get(&self, key: Tag) -> Option<&Table>
+//{
+//self.0.get(&key).map(RefCell::borrow).as_deref()
+//}
+
+//pub fn get_mut(&mut self, key: Tag) -> Option<&mut Table> {
+//self.0.get(&key).map(RefCell::borrow_mut).as_deref_mut()
+//}
+
+//pub fn remove(&mut self, key: Tag) -> Option<Table>
+//{
+//self.0.remove(&key).map(RefCell::into_inner)
+//}
+
+//pub fn insert(&mut self, key: Tag, table: Table) -> Option<Table>
+//{
+//self.0.insert(key, RefCell::new(table)).map(RefCell::into_inner)
+//}
+//}

--- a/src/table_store.rs
+++ b/src/table_store.rs
@@ -1,10 +1,26 @@
-use std::borrow::Borrow;
-use std::{any::Any, cell::RefCell, collections::BTreeMap, rc::Rc};
+use std::{
+    borrow::Borrow,
+    cell::RefCell,
+    collections::BTreeMap,
+    convert::{TryFrom, TryInto},
+    fmt::Debug,
+    ops::Deref,
+    rc::Rc,
+};
 
-use otspec::types::{tag, Tag};
-use otspec::{DeserializationError, ReaderContext};
+use otspec::types::Tag;
+use otspec::{DeserializationError, ReaderContext, SerializationError, Serialize};
 
 use crate::tables;
+
+/// A helper used to build a `TableSet` during deserialization.
+///
+/// This ensures that a newly constructed table preloads required tables,
+/// and ensures that the TableSet is initialized correctly.
+#[derive(Debug, Default)]
+pub struct TableLoader {
+    inner: TableSet,
+}
 
 /// A lazy loader for the set of OpenType tables in a font.
 #[derive(Debug, Default)]
@@ -12,40 +28,191 @@ pub struct TableSet {
     tables: BTreeMap<Tag, RefCell<LazyItem>>,
 }
 
-#[derive(Debug)]
+/// A table in a font, which may or may not have been loaded yet.
+#[derive(Debug, PartialEq)]
 enum LazyItem {
     Unloaded(Rc<[u8]>),
-    Loaded(Rc<dyn Any>),
-    Error(DeserializationError),
+    Loaded(Table),
 }
 
-/// An unknown table.
-#[derive(Debug, Clone)]
-pub struct UnknownTable {
-    /// The raw data for this table.
-    pub data: Rc<[u8]>,
+/// Any OpenType table.
+//TODO: we can probably get rid of this and just use `TableData`?
+#[derive(Clone, Debug, PartialEq)]
+pub struct Table {
+    tag: Tag,
+    data: TableData,
+}
+
+impl Table {
+    /// If this table is of a known type, return a `KnownTable`.
+    pub fn known(&self) -> Option<KnownTable> {
+        match &self.data {
+            TableData::Known { typed, .. } => Some(typed.clone()),
+            _ => None,
+        }
+    }
+
+    /// If this table is of an unknown type, return the raw bytes.
+    pub fn unknown(&self) -> Option<Rc<[u8]>> {
+        match &self.data {
+            TableData::Unknown { raw } => Some(raw.clone()),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+enum TableData {
+    /// A table of a known type.
+    Known {
+        /// The raw data for serialization.
+        ///
+        /// This is only `Some` if this table was loaded from existing data,
+        /// or if this table has already been serialized.
+        raw: Option<Rc<[u8]>>,
+        /// The typed table. This is one of the types defined in the `tables`
+        /// module.
+        typed: KnownTable,
+    },
+    /// A table we don't know how to represent; we just hold on to the bits.
+    Unknown { raw: Rc<[u8]> },
+}
+
+/// An OpenType table of a known format.
+#[derive(Clone, Debug, PartialEq)]
+#[allow(non_camel_case_types, clippy::upper_case_acronyms)]
+pub enum KnownTable {
+    /// Contains an axis variations table.
+    avar(Rc<tables::avar::avar>),
+    /// Contains a character to glyph index mapping table.
+    cmap(Rc<tables::cmap::cmap>),
+    /// Contains a font variations table.
+    fvar(Rc<tables::fvar::fvar>),
+    /// Contains a grid-fitting and scan-conversion procedure table.
+    gasp(Rc<tables::gasp::gasp>),
+    /// Contains a tables::glyph::glyph definition table.
+    GDEF(Rc<tables::GDEF::GDEF>),
+    /// Contains a glyph positioning table.
+    GPOS(Rc<tables::GPOS::GPOS>),
+    /// Contains a glyph substitution table.
+    GSUB(Rc<tables::GSUB::GSUB>),
+    /// Contains a glyph data table.
+    glyf(Rc<tables::glyf::glyf>),
+    /// Contains a glyph variations table.
+    gvar(Rc<tables::gvar::gvar>),
+    /// Contains a header table.
+    head(Rc<tables::head::head>),
+    /// Contains a horizontal header table.
+    hhea(Rc<tables::hhea::hhea>),
+    /// Contains a horizontal metrics table.
+    hmtx(Rc<tables::hmtx::hmtx>),
+    /// Contains an index-to-location table.
+    loca(Rc<tables::loca::loca>),
+    /// Contains a math typesetting table.
+    MATH(Rc<tables::MATH::MATH>),
+    /// Contains a maximum profile table.
+    maxp(Rc<tables::maxp::maxp>),
+    /// Contains a naming table.
+    name(Rc<tables::name::name>),
+    /// Contains an OS/2 and Windows metrics table.
+    os2(Rc<tables::os2::os2>),
+    /// Contains a postscript table.
+    post(Rc<tables::post::post>),
+    /// Contains a style attributes table.
+    STAT(Rc<tables::STAT::STAT>),
+}
+
+/// A reference-counted pointer with transparent copy-on-write semantics.
+///
+/// Accessing a mutating method on the inner type will cause a clone of
+/// the inner data if there are other outstanding references to this pointer.
+///
+/// # Note
+///
+/// This may be too fancy? It is an attempt to make the API more clear, by
+/// avoiding the need to do `Rc::make_mut(&mut my_table)` every time the user
+/// wants to mutate a table.
+pub struct Cow<T> {
+    inner: Rc<T>,
+}
+
+impl<T: Clone> std::ops::Deref for Cow<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+// any access to a mutating method will cause us to ensure we point to unique
+// data.
+impl<T: Clone> std::ops::DerefMut for Cow<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        Rc::make_mut(&mut self.inner)
+    }
+}
+
+impl TableLoader {
+    /// Add a raw table to the `TableSet`.
+    pub fn add(&mut self, tag: Tag, data: Rc<[u8]>) {
+        self.inner
+            .tables
+            .insert(tag, RefCell::new(LazyItem::Unloaded(data)));
+    }
+
+    /// Load required tables and return the `TableSet`.
+    pub fn finish(self) -> Result<TableSet, DeserializationError> {
+        let tables = self.inner;
+        tables.load_if_needed(tables::head::TAG)?;
+        tables.load_if_needed(tables::loca::TAG)?;
+        Ok(tables)
+    }
 }
 
 impl TableSet {
+    /// The number of tables in this set.
     pub fn len(&self) -> usize {
         self.tables.len()
     }
 
-    /// Get a table that has already been loaded.
-    ///
-    /// If the table has not been loaded this will return `None`, even if it
-    /// exists.
-    pub fn get_no_load<T: Any>(&self, tag: Tag) -> Option<&T> {
-        self.tables
-            .get(&tag)
-            .and_then(|item| item.borrow().loaded())
-            .map(|t| t.downcast_ref().expect("invalid type in table"))
+    /// Attempt to deserialize all the tables in this set.
+    pub fn fully_deserialize(&self) -> Result<(), DeserializationError> {
+        // Order is important
+        self.load_if_needed(tables::head::TAG)?;
+        self.load_if_needed(tables::maxp::TAG)?;
+        if self.tables.contains_key(&tables::glyf::TAG) {
+            self.load_if_needed(tables::loca::TAG)?;
+            self.load_if_needed(tables::glyf::TAG)?;
+        }
+
+        for tag in self.keys() {
+            if let Err(e) = self.load_if_needed(tag) {
+                log::warn!("Couldn't deserilaize {}: '{}'", tag, e);
+            }
+        }
+
+        Ok(())
     }
 
     /// Get a table, attempting to load it if necessary.
-    pub fn get<T: Any>(&self, tag: Tag) -> Result<Option<&T>, DeserializationError> {
+    ///
+    /// For known tables, you should prefer to use the typed methods such
+    /// as [`name`], [`GDEF`], etc. These methods exist for each table defined
+    /// in the [`tables`] module.
+    ///
+    /// [`name`]: TableSet::name
+    /// [`GDEF`]: TableSet::GDEF
+    /// [`tables`]: crate::tables
+    pub fn get(&self, tag: Tag) -> Result<Option<Table>, DeserializationError> {
         self.load_if_needed(tag)?;
-        Ok(self.get_no_load(tag))
+        Ok(self
+            .tables
+            .get(&tag)
+            .map(|item| item.borrow().loaded().unwrap()))
+    }
+
+    /// Returns an iterator over the `Tag`s of the tables in this set.
+    pub fn keys(&self) -> impl Iterator<Item = Tag> + '_ {
+        self.tables.keys().cloned()
     }
 
     /// Returns `true` if the provided tag is a table in this `TableSet`.
@@ -57,8 +224,47 @@ impl TableSet {
         self.tables.contains_key(table)
     }
 
-    pub fn remove(&mut self, table: Tag) -> Option<()> {
-        self.tables.remove(&table).map(|_| ())
+    /// Remove a table from this set.
+    ///
+    /// If the exists and was loaded, it is returned.
+    //TODO: is this too fancy? we don't want to return `LazyItem`
+    // (which is private API) and we also don't want to try loading before
+    // removing. Will anyone use this? one *possible* case is slightly more
+    // efficient mutation, avoiding the table clone?
+    pub fn remove(&mut self, table: Tag) -> Option<Table> {
+        self.tables
+            .remove(&table)
+            .and_then(|item| item.into_inner().loaded())
+    }
+
+    /// Insert a known table into this set, replacing any existing table.
+    ///
+    /// To insert an unknown table, use [`insert_raw`].
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # fn make_name_table() -> tables::name::name { unreachable!("just for show") }
+    /// use fonttools::{tables, font::{SfntVersion, Font}};
+    ///
+    /// let mut font = Font::new(SfntVersion::OpenType);
+    /// let name_table: tables::name::name = make_name_table();
+    /// font.tables.insert(name_table);
+    /// ```
+    pub fn insert(&mut self, table: impl Into<Table>) {
+        let table = table.into();
+        let tag = table.tag;
+        let table = RefCell::new(LazyItem::Loaded(table));
+        self.tables.insert(tag, table);
+    }
+
+    /// Assign raw binary data to a table.
+    ///
+    /// If the table is typed and exists, it is removed and will be reloaded
+    /// on the next access.
+    fn insert_raw(&mut self, tag: Tag, data: impl Into<Rc<[u8]>>) {
+        self.tables
+            .insert(tag, RefCell::new(LazyItem::Unloaded(data.into())));
     }
 
     fn load_if_needed(&self, tag: Tag) -> Result<(), DeserializationError> {
@@ -67,10 +273,9 @@ impl TableSet {
             _ => return Ok(()),
         };
 
-        let to_load = match *item.borrow() {
+        let to_load = match &*item.borrow() {
             LazyItem::Unloaded(data) => data.clone(),
-            LazyItem::Error(e) => return Err(e.clone()),
-            LazyItem::Loaded(_) => unreachable!(),
+            LazyItem::Loaded(_) => return Ok(()),
         };
 
         let loaded_table = self.deserialize_table(tag, to_load)?;
@@ -78,58 +283,58 @@ impl TableSet {
         Ok(())
     }
 
-    fn deserialize_table(
-        &self,
-        tag: Tag,
-        data: Rc<[u8]>,
-    ) -> Result<Rc<dyn Any>, DeserializationError> {
-        let table: Rc<dyn Any> = match tag.as_bytes() {
-            b"avar" => Rc::new(otspec::de::from_bytes::<tables::avar::avar>(&data)?),
-            b"cmap" => Rc::new(otspec::de::from_bytes::<tables::cmap::cmap>(&data)?),
-            b"fvar" => Rc::new(otspec::de::from_bytes::<tables::fvar::fvar>(&data)?),
-            b"gasp" => Rc::new(otspec::de::from_bytes::<tables::gasp::gasp>(&data)?),
-            b"GDEF" => Rc::new(otspec::de::from_bytes::<tables::GDEF::GDEF>(&data)?),
-            b"GPOS" => Rc::new(otspec::de::from_bytes::<tables::GPOS::GPOS>(&data)?),
-            b"GSUB" => Rc::new(otspec::de::from_bytes::<tables::GSUB::GSUB>(&data)?),
-            b"head" => Rc::new(otspec::de::from_bytes::<tables::head::head>(&data)?),
-            b"hhea" => Rc::new(otspec::de::from_bytes::<tables::hhea::hhea>(&data)?),
-            b"MATH" => Rc::new(otspec::de::from_bytes::<tables::MATH::MATH>(&data)?),
-            b"maxp" => Rc::new(otspec::de::from_bytes::<tables::maxp::maxp>(&data)?),
-            b"name" => Rc::new(otspec::de::from_bytes::<tables::name::name>(&data)?),
-            b"OS/2" => Rc::new(otspec::de::from_bytes::<tables::os2::os2>(&data)?),
-            b"post" => Rc::new(otspec::de::from_bytes::<tables::post::post>(&data)?),
-            b"STAT" => Rc::new(otspec::de::from_bytes::<tables::STAT::STAT>(&data)?),
+    fn deserialize_table(&self, tag: Tag, data: Rc<[u8]>) -> Result<Table, DeserializationError> {
+        let typed_data: Option<KnownTable> = match tag.as_bytes() {
+            b"avar" => Some(otspec::de::from_bytes::<tables::avar::avar>(&data)?.into()),
+            b"cmap" => Some(otspec::de::from_bytes::<tables::cmap::cmap>(&data)?.into()),
+            b"fvar" => Some(otspec::de::from_bytes::<tables::fvar::fvar>(&data)?.into()),
+            b"gasp" => Some(otspec::de::from_bytes::<tables::gasp::gasp>(&data)?.into()),
+            b"GDEF" => Some(otspec::de::from_bytes::<tables::GDEF::GDEF>(&data)?.into()),
+            b"GPOS" => Some(otspec::de::from_bytes::<tables::GPOS::GPOS>(&data)?.into()),
+            b"GSUB" => Some(otspec::de::from_bytes::<tables::GSUB::GSUB>(&data)?.into()),
+            b"head" => Some(otspec::de::from_bytes::<tables::head::head>(&data)?.into()),
+            b"hhea" => Some(otspec::de::from_bytes::<tables::hhea::hhea>(&data)?.into()),
+            b"MATH" => Some(otspec::de::from_bytes::<tables::MATH::MATH>(&data)?.into()),
+            b"maxp" => Some(otspec::de::from_bytes::<tables::maxp::maxp>(&data)?.into()),
+            b"name" => Some(otspec::de::from_bytes::<tables::name::name>(&data)?.into()),
+            b"OS/2" => Some(otspec::de::from_bytes::<tables::os2::os2>(&data)?.into()),
+            b"post" => Some(otspec::de::from_bytes::<tables::post::post>(&data)?.into()),
+            b"STAT" => Some(otspec::de::from_bytes::<tables::STAT::STAT>(&data)?.into()),
             b"hmtx" => {
                 let number_of_hmetrics = self
-                    .get_no_load::<tables::hhea::hhea>(tag!("hhea"))
+                    //TODO: dear reviewer: this loads the table if missing. do
+                    //we want to force the user to do this explicitly?
+                    .hhea()?
                     .map(|hhea| hhea.numberOfHMetrics)
+                    //TODO: are we allowed to not have hhea?
                     .ok_or_else(|| DeserializationError("deserialize hhea before hmtx".into()))?;
-                Rc::new(tables::hmtx::from_bytes(
-                    &mut ReaderContext::new(data.to_vec()),
-                    number_of_hmetrics,
-                )?)
+                Some(
+                    tables::hmtx::from_bytes(
+                        &mut ReaderContext::new(data.to_vec()),
+                        number_of_hmetrics,
+                    )?
+                    .into(),
+                )
             }
             b"loca" => {
                 let is_32bit = self
-                    .get_no_load::<tables::head::head>(tag!("head"))
+                    .head()?
                     .map(|head| head.indexToLocFormat == 1)
                     .ok_or_else(|| DeserializationError("deserialize head before loca".into()))?;
-                Rc::new(tables::loca::from_bytes(
-                    &mut ReaderContext::new(data.to_vec()),
-                    is_32bit,
-                )?)
+                Some(
+                    tables::loca::from_bytes(&mut ReaderContext::new(data.to_vec()), is_32bit)?
+                        .into(),
+                )
             }
             b"glyf" => {
-                let loca_offsets = self
-                    .get_no_load::<tables::loca::loca>(tag!("loca"))
-                    .map(|loca| &loca.indices)
+                let loca = self
+                    .loca()?
                     .ok_or_else(|| DeserializationError("deserialize loca before glyf".into()))?;
-                Rc::new(tables::glyf::from_bytes(&data, loca_offsets)?)
+                Some(tables::glyf::from_bytes(&data, &loca.indices)?.into())
             }
             b"gvar" => {
                 let glyf = self
-                    .get_no_load::<tables::glyf::glyf>(tag!("glyf"))
-                    //.map(|glyf| &loca.indices)
+                    .glyf()?
                     .ok_or_else(|| DeserializationError("deserialize glyf before gvar".into()))?;
                 let coords_and_ends = glyf
                     .glyphs
@@ -137,136 +342,273 @@ impl TableSet {
                     .map(|g| g.gvar_coords_and_ends())
                     .collect();
 
-                Rc::new(tables::gvar::from_bytes(&data, coords_and_ends)?)
+                Some(tables::gvar::from_bytes(&data, coords_and_ends)?.into())
             }
-            _ => Rc::new(data.to_owned()),
+            _ => None,
         };
-        Ok(table)
+
+        let data = match typed_data {
+            Some(typed) => TableData::Known {
+                raw: Some(data),
+                typed,
+            },
+            None => TableData::Unknown { raw: data },
+        };
+        Ok(Table { data, tag })
+    }
+
+    fn is_serialized(&self, tag: Tag) -> Option<bool> {
+        self.tables
+            .get(&tag)
+            .map(|table| match table.borrow().deref() {
+                LazyItem::Unloaded(_) => true,
+                LazyItem::Loaded(table) => match &table.data {
+                    TableData::Known { raw, .. } => raw.is_some(),
+                    TableData::Unknown { .. } => true,
+                },
+            })
+    }
+
+    pub(crate) fn compile_glyf_loca_maxp(&mut self) {
+        // leave early if we have no work to do.
+        if self.is_serialized(tables::glyf::TAG).unwrap_or(true)
+            && self.is_serialized(tables::loca::TAG).unwrap_or(true)
+            && self.is_serialized(tables::maxp::TAG).unwrap_or(true)
+        {
+            return;
+        }
+        let glyf = match self.glyf().unwrap() {
+            Some(table) => table,
+            None => {
+                println!("Warning: no glyf table");
+                return;
+            }
+        };
+        let glyf_count = glyf.glyphs.len();
+        let mut glyf_output: Vec<u8> = vec![];
+        let mut loca_indices: Vec<u32> = vec![];
+
+        for g in &glyf.glyphs {
+            let cur_len: u32 = glyf_output.len().try_into().unwrap();
+            loca_indices.push(cur_len);
+            if g.is_empty() {
+                continue;
+            }
+            glyf_output.extend(otspec::ser::to_bytes(&g).unwrap());
+            // Add multiple-of-four padding
+            while glyf_output.len() % 4 != 0 {
+                glyf_output.push(0);
+            }
+        }
+        loca_indices.push(glyf_output.len().try_into().unwrap());
+        let loca_is32bit = u16::try_from(glyf_output.len()).is_err();
+
+        let loca_data = if loca_is32bit {
+            otspec::ser::to_bytes(&loca_indices).unwrap()
+        } else {
+            let mut data = Vec::with_capacity(loca_indices.len() * 2);
+            loca_indices
+                .iter()
+                .map(|x| ((*x / 2) as u16))
+                .for_each(|x| x.to_bytes(&mut data).unwrap());
+            data
+        };
+
+        self.insert_raw(tables::glyf::TAG, glyf_output);
+        self.insert_raw(tables::loca::TAG, loca_data);
+
+        let mut maxp = self.maxp().unwrap().unwrap().clone();
+        maxp.set_num_glyphs(glyf_count.try_into().unwrap());
+
+        let mut head = self.head().unwrap().unwrap().clone();
+        head.indexToLocFormat = if loca_is32bit { 1 } else { 0 };
+        self.insert(head);
+
+        if let Some(hmetric_count) = self.hmtx().unwrap().map(|t| t.number_of_hmetrics()) {
+            if let Some(mut hhea) = self.hhea().unwrap() {
+                hhea.numberOfHMetrics = hmetric_count;
+                self.insert(hhea);
+            }
+        }
+    }
+
+    pub(crate) fn write_table(
+        &self,
+        tag: Tag,
+        buffer: &mut Vec<u8>,
+    ) -> Result<(), SerializationError> {
+        let table = match self.tables.get(&tag) {
+            Some(table) => table,
+            None => return Ok(()),
+        };
+
+        match &*table.borrow() {
+            LazyItem::Unloaded(raw) => raw.to_bytes(buffer),
+            LazyItem::Loaded(table) => match &table.data {
+                TableData::Unknown { raw } => raw.to_bytes(buffer),
+                TableData::Known {
+                    raw: Some(data), ..
+                } => data.to_bytes(buffer),
+                TableData::Known { typed, .. } => typed.to_bytes(buffer),
+            },
+        }
     }
 }
 
 impl LazyItem {
-    fn loaded(&self) -> Option<&dyn Any> {
+    fn loaded(&self) -> Option<Table> {
         match self {
             LazyItem::Unloaded(_) => None,
-            LazyItem::Error(_) => None,
-            LazyItem::Loaded(thing) => Some(thing),
+            LazyItem::Loaded(thing) => Some(thing.clone()),
         }
-    }
-
-    fn needs_load(&self) -> bool {
-        matches!(self, LazyItem::Unloaded(_))
     }
 }
 
-//fn load(&mut self, tag: Tag) -> Result<(), DeserializationError> {
-//let data = match self.unloaded.remove(&tag) {
-//Some(data) => data,
-//None => return Ok(()),
-//};
+impl PartialEq for TableSet {
+    fn eq(&self, other: &Self) -> bool {
+        self.tables.len() == other.tables.len()
+            && self
+                .tables
+                .iter()
+                .zip(other.tables.iter())
+                .all(|((k1, v1), (k2, v2))| k1 == k2 && *v1.borrow() == *v2.borrow())
+    }
+}
 
-//let data: Rc<dyn Any> = match tag.as_str() {
-//"avar" => Rc::new(otspec::de::from_bytes::<tables::avar::avar>(&data)?),
-//"cmap" => Rc::new(otspec::de::from_bytes::<tables::cmap::cmap>(&data)?),
-//// other tables here
-//other => Rc::new(data),
-//};
-//self.loaded.insert(tag, data);
-//Ok(())
-//}
+impl PartialEq for TableData {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Known { typed: one, .. }, Self::Known { typed: two, .. }) => one == two,
+            (Self::Unknown { raw: one }, Self::Unknown { raw: two }) => one == two,
+            _ => false,
+        }
+    }
+}
 
-//fn load_tables(&mut self, tables: &[Tag]) -> Result<(), DeserializationError> {
-//for tag in tables {
-//self.load(*tag)?;
-//}
-//Ok(())
-//}
+impl KnownTable {
+    fn tag(&self) -> Tag {
+        match self {
+            KnownTable::avar(_) => tables::avar::TAG,
+            KnownTable::cmap(_) => tables::cmap::TAG,
+            KnownTable::fvar(_) => tables::fvar::TAG,
+            KnownTable::gasp(_) => tables::gasp::TAG,
+            KnownTable::GDEF(_) => tables::GDEF::TAG,
+            KnownTable::GPOS(_) => tables::GPOS::TAG,
+            KnownTable::GSUB(_) => tables::GSUB::TAG,
+            KnownTable::glyf(_) => tables::glyf::TAG,
+            KnownTable::gvar(_) => tables::gvar::TAG,
+            KnownTable::head(_) => tables::head::TAG,
+            KnownTable::hhea(_) => tables::hhea::TAG,
+            KnownTable::hmtx(_) => tables::hmtx::TAG,
+            KnownTable::loca(_) => tables::loca::TAG,
+            KnownTable::maxp(_) => tables::maxp::TAG,
+            KnownTable::name(_) => tables::name::TAG,
+            KnownTable::os2(_) => tables::os2::TAG,
+            KnownTable::post(_) => tables::post::TAG,
+            KnownTable::STAT(_) => tables::STAT::TAG,
+            KnownTable::MATH(_) => tables::MATH::TAG,
+        }
+    }
+}
 
-//fn needs_to_deserialize(&self, table: Tag) -> bool {
-//self.unloaded.contains_key(&table)
-//}
+// a little helper to ensure at compile time that tables are Clone;
+// we need this for copy-on-write semanatics
+fn assert_is_clone<T: Clone>() {}
 
-//fn get_or_deserialize<T: Any>(
-//&mut self,
-//tag: Tag,
-//d: impl FnOnce(&[u8]) -> Result<T, DeserializationError>,
-//) -> Result<Option<Rc<T>, DeserializationError>> {
+macro_rules! from_table {
+    ($table:ty, $enum: ident) => {
+        impl From<$table> for KnownTable {
+            fn from(src: $table) -> KnownTable {
+                KnownTable::$enum(Rc::new(src))
+            }
+        }
 
-//}
+        impl From<$table> for Table {
+            fn from(src: $table) -> Table {
+                Table::from(Cow {
+                    inner: Rc::new(src),
+                })
+            }
+        }
 
-//fn gpos(&self) -> Option<&crate::GPOS::GPOS> {
-//self.get_typed(GPOS_TAG)
-//}
+        impl From<Cow<$table>> for Table {
+            fn from(src: Cow<$table>) -> Table {
+                let typed = KnownTable::$enum(src.inner);
+                let tag = typed.tag();
+                Table {
+                    data: TableData::Known { raw: None, typed },
+                    tag,
+                }
+            }
+        }
 
-//fn gpos_mut(&mut self) -> Option<&mut crate::GPOS::GPOS> {
-//self.get_typed_mut(GPOS_TAG)
-//}
+        impl KnownTable {
+            #[allow(non_snake_case)]
+            fn $enum(&self) -> Cow<$table> {
+                assert_is_clone::<$table>();
 
-//fn get_typed<T: Any>(&self, tag: Tag) -> Option<&T> {
-//assert!(
-// !self.unloaded.borrow().contains_key(&tag),
-//"tables must be loaded before use"
-//);
-//self.loaded
-//.get(&tag)
-//.map(|t| t.downcast_ref().expect("wrong type for tag"))
-//}
+                if let Self::$enum(table) = self {
+                    return Cow {
+                        inner: table.clone(),
+                    };
+                } else {
+                    panic!("expected '{}' found '{}'", stringify!($ident), self.tag());
+                }
+            }
+        }
 
-//fn get_typed_mut<T: Any>(&mut self, tag: Tag) -> Option<&mut T> {
-//assert!(
-// !self.unloaded.contains_key(&tag),
-//"tables must be loaded before use"
-//);
-//self.loaded
-//.get_mut(&tag)
-//.map(|t| t.downcast_mut().expect("wrong type for tag"))
-//}
+        impl TableSet {
+            #[allow(non_snake_case)]
 
-//fn other_table(&self, tag: Tag) -> Option<&[u8]> {
-//self.unloaded.get(&tag).map(Vec::as_slice)
-//}
-//}
+            pub fn $enum(&self) -> Result<Option<Cow<$table>>, DeserializationError> {
+                Ok(self.get(tables::$enum::TAG)?.map(|t| t.known().expect(stringify!($enum is known table type)).$enum()))
+            }
+        }
+    };
+}
 
-//#[derive(Debug, Default)]
-//pub struct Tables(BTreeMap<Tag, RefCell<Table>>);
+from_table!(tables::GDEF::GDEF, GDEF);
+from_table!(tables::GPOS::GPOS, GPOS);
+from_table!(tables::GSUB::GSUB, GSUB);
+from_table!(tables::STAT::STAT, STAT);
+from_table!(tables::avar::avar, avar);
+from_table!(tables::cmap::cmap, cmap);
+from_table!(tables::fvar::fvar, fvar);
+from_table!(tables::gasp::gasp, gasp);
+from_table!(tables::glyf::glyf, glyf);
+from_table!(tables::gvar::gvar, gvar);
+from_table!(tables::head::head, head);
+from_table!(tables::hhea::hhea, hhea);
+from_table!(tables::hmtx::hmtx, hmtx);
+from_table!(tables::loca::loca, loca);
+from_table!(tables::maxp::maxp, maxp);
+from_table!(tables::name::name, name);
+from_table!(tables::os2::os2, os2);
+from_table!(tables::post::post, post);
+from_table!(tables::MATH::MATH, MATH);
 
-//impl Tables {
-//pub fn len(&self) -> usize {
-//self.0.len()
-//}
-
-//pub fn is_empty(&self) -> bool {
-//self.0.is_empty()
-//}
-
-////pub fn iter(&self) -> impl Iterator<Item = (&Tag, &Table)> {
-////self.0.iter().map(|(a, b)| (a, b.borrow().deref()))
-////}
-
-//pub fn keys(&self) -> impl Iterator<Item = &Tag> {
-//self.0.keys()
-//}
-
-//pub fn contains_key(&self, key: Tag) -> bool {
-//self.0.contains_key(&key)
-//}
-
-//pub fn get(&self, key: Tag) -> Option<&Table>
-//{
-//self.0.get(&key).map(RefCell::borrow).as_deref()
-//}
-
-//pub fn get_mut(&mut self, key: Tag) -> Option<&mut Table> {
-//self.0.get(&key).map(RefCell::borrow_mut).as_deref_mut()
-//}
-
-//pub fn remove(&mut self, key: Tag) -> Option<Table>
-//{
-//self.0.remove(&key).map(RefCell::into_inner)
-//}
-
-//pub fn insert(&mut self, key: Tag, table: Table) -> Option<Table>
-//{
-//self.0.insert(key, RefCell::new(table)).map(RefCell::into_inner)
-//}
-//}
+impl Serialize for KnownTable {
+    fn to_bytes(&self, data: &mut Vec<u8>) -> Result<(), otspec::SerializationError> {
+        match self {
+            KnownTable::avar(expr) => expr.to_bytes(data),
+            KnownTable::cmap(expr) => expr.to_bytes(data),
+            KnownTable::fvar(expr) => expr.to_bytes(data),
+            KnownTable::gasp(expr) => expr.to_bytes(data),
+            KnownTable::GSUB(expr) => expr.to_bytes(data),
+            KnownTable::GDEF(expr) => expr.to_bytes(data),
+            KnownTable::GPOS(expr) => expr.to_bytes(data),
+            KnownTable::gvar(_) => unimplemented!(),
+            KnownTable::head(expr) => expr.to_bytes(data),
+            KnownTable::hhea(expr) => expr.to_bytes(data),
+            KnownTable::hmtx(_) => unimplemented!(),
+            KnownTable::glyf(_) => unimplemented!(),
+            KnownTable::loca(_) => unimplemented!(),
+            KnownTable::maxp(expr) => expr.to_bytes(data),
+            KnownTable::MATH(_) => unimplemented!(),
+            KnownTable::name(expr) => expr.to_bytes(data),
+            KnownTable::os2(expr) => expr.to_bytes(data),
+            KnownTable::post(expr) => expr.to_bytes(data),
+            KnownTable::STAT(expr) => expr.to_bytes(data),
+        }
+    }
+}

--- a/src/tables/GDEF.rs
+++ b/src/tables/GDEF.rs
@@ -3,6 +3,7 @@ use crate::layout::coverage::Coverage;
 use crate::layout::device::Device;
 use crate::otvar::ItemVariationStore;
 use otspec::types::*;
+use otspec::Serializer;
 use std::iter::FromIterator;
 
 use otspec::{
@@ -95,8 +96,22 @@ pub enum CaretValue {
 }
 
 impl Serialize for CaretValue {
-    fn to_bytes(&self, _data: &mut Vec<u8>) -> Result<(), SerializationError> {
-        todo!()
+    fn to_bytes(&self, data: &mut Vec<u8>) -> Result<(), SerializationError> {
+        match &self {
+            Self::Format1 { coordinate } => {
+                data.put(1_u16)?;
+                data.put(coordinate)
+            }
+            Self::Format2 { pointIndex } => {
+                data.put(2_u16)?;
+                data.put(pointIndex)
+            }
+            Self::Format3 { coordinate, device } => {
+                data.put(3_u16)?;
+                data.put(coordinate)?;
+                device.to_bytes(data)
+            }
+        }
     }
 
     fn offset_fields(&self) -> Vec<&dyn OffsetMarkerTrait> {

--- a/src/tables/GDEF.rs
+++ b/src/tables/GDEF.rs
@@ -11,6 +11,9 @@ use otspec::{
 use otspec_macros::tables;
 use std::collections::{BTreeMap, BTreeSet};
 
+/// The 'GDEF' OpenType tag.
+pub const TAG: Tag = crate::tag!("GDEF");
+
 // Having version-specific tables makes it so much easier to keep track of
 // the offset fields
 tables!(

--- a/src/tables/GPOS.rs
+++ b/src/tables/GPOS.rs
@@ -15,6 +15,9 @@ use otspec::{
 use otspec_macros::Deserialize;
 use std::convert::TryInto;
 
+/// The 'GPOS' OpenType tag.
+pub const TAG: Tag = crate::tag!("GPOS");
+
 impl Lookup<Positioning> {
     /// Return the integer GPOS lookup type for this lookup
     pub fn lookup_type(&self) -> u16 {

--- a/src/tables/GSUB.rs
+++ b/src/tables/GSUB.rs
@@ -13,6 +13,9 @@ use otspec::{
 use otspec_macros::Deserialize;
 use std::convert::TryInto;
 
+/// The 'GSUB' OpenType tag.
+pub const TAG: Tag = crate::tag!("GSUB");
+
 impl Lookup<Substitution> {
     /// Return the integer GSUB lookup type for this lookup
     pub fn lookup_type(&self) -> u16 {

--- a/src/tables/MATH.rs
+++ b/src/tables/MATH.rs
@@ -6,6 +6,9 @@ use otspec::{DeserializationError, Deserialize, Deserializer, Serialize, Seriali
 use otspec_macros::{tables, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
+/// The 'MATH' OpenType tag.
+pub const TAG: Tag = crate::tag!("MATH");
+
 tables!(
     MathValueRecord [embedded] {
         FWORD value

--- a/src/tables/STAT.rs
+++ b/src/tables/STAT.rs
@@ -102,7 +102,7 @@ pub struct AxisValue {
     pub locations: Option<BTreeMap<uint16, f32>>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[allow(clippy::upper_case_acronyms)]
 /// The Style Attributes table
 pub struct STAT {

--- a/src/tables/STAT.rs
+++ b/src/tables/STAT.rs
@@ -7,6 +7,9 @@ use otspec::{
 use otspec_macros::{tables, Deserialize, Serialize};
 use std::collections::BTreeMap;
 
+/// The 'STAT' OpenType tag.
+pub const TAG: Tag = crate::tag!("STAT");
+
 tables!(STATcore {
     uint16 majorVersion
     uint16 minorVersion

--- a/src/tables/avar.rs
+++ b/src/tables/avar.rs
@@ -2,6 +2,9 @@ use otspec::types::*;
 use otspec::Deserializer;
 use otspec_macros::tables;
 
+/// The 'avar' OpenType tag.
+pub const TAG: Tag = crate::tag!("avar");
+
 tables!(
     AxisValueMap {
         F2DOT14 fromCoordinate

--- a/src/tables/cmap.rs
+++ b/src/tables/cmap.rs
@@ -9,6 +9,9 @@ use std::collections::{BTreeMap, HashSet};
 use std::convert::TryInto;
 use std::hash::{Hash, Hasher};
 
+/// The 'cmap' OpenType tag.
+pub const TAG: Tag = crate::tag!("cmap");
+
 tables!(
 
 EncodingRecord {

--- a/src/tables/cmap.rs
+++ b/src/tables/cmap.rs
@@ -28,7 +28,7 @@ CmapHeader {
 
 );
 
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 #[allow(non_camel_case_types, non_snake_case)]
 struct cmap0 {
     format: uint16,
@@ -70,7 +70,7 @@ impl Deserialize for cmap0 {
 }
 
 #[allow(non_camel_case_types, non_snake_case)]
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 /// A format 4 cmap subtable, used for mapping Unicode characters in the
 /// basic mutilingual plane.
 pub struct cmap4 {
@@ -500,7 +500,7 @@ impl cmap14 {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[allow(non_snake_case)]
 /// A cmap subtable.
 ///
@@ -554,7 +554,7 @@ impl Serialize for CmapSubtable {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[allow(non_camel_case_types)]
 /// cmap table. The cmap table is a collection of subtables, as described above.
 pub struct cmap {

--- a/src/tables/fvar.rs
+++ b/src/tables/fvar.rs
@@ -69,7 +69,7 @@ impl InstanceRecord {
 }
 
 /// Represents a font's fvar (Font Variations) table
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[allow(non_camel_case_types)]
 pub struct fvar {
     /// The font's axes of variation

--- a/src/tables/fvar.rs
+++ b/src/tables/fvar.rs
@@ -5,6 +5,9 @@ use otspec::{
 };
 use otspec_macros::tables;
 
+/// The 'fvar' OpenType tag.
+pub const TAG: Tag = crate::tag!("fvar");
+
 tables!(
     fvarcore {
         uint16 majorVersion
@@ -144,7 +147,7 @@ impl Serialize for fvar {
 
 #[cfg(test)]
 mod tests {
-    use crate::tables::fvar::{self, InstanceRecord};
+    use crate::tables::fvar::InstanceRecord;
     use crate::tag;
 
     #[test]

--- a/src/tables/gasp.rs
+++ b/src/tables/gasp.rs
@@ -3,6 +3,9 @@ use otspec::types::*;
 use otspec::Deserializer;
 use otspec_macros::{tables, Deserialize, Serialize};
 
+/// The 'gasp' OpenType tag.
+pub const TAG: Tag = crate::tag!("gasp");
+
 tables!(
 GaspRecord {
     uint16 rangeMaxPPEM

--- a/src/tables/glyf.rs
+++ b/src/tables/glyf.rs
@@ -14,6 +14,9 @@ pub use component::{Component, ComponentFlags};
 pub use glyph::Glyph;
 pub use point::Point;
 
+/// The 'glyf' OpenType tag.
+pub const TAG: otspec::types::Tag = crate::tag!("glyf");
+
 /// The glyf table
 #[allow(non_camel_case_types)]
 #[derive(Debug, PartialEq, Clone)]

--- a/src/tables/glyf.rs
+++ b/src/tables/glyf.rs
@@ -28,7 +28,7 @@ pub struct glyf {
 /// Deserialize the glyf table from a binary buffer.
 ///
 /// loca_offsets must be obtained from the `loca` table.
-pub fn from_bytes(c: &[u8], loca_offsets: Vec<Option<u32>>) -> Result<glyf, DeserializationError> {
+pub fn from_bytes(c: &[u8], loca_offsets: &[Option<u32>]) -> Result<glyf, DeserializationError> {
     from_rc(&mut ReaderContext::new(c.to_vec()), loca_offsets)
 }
 
@@ -37,7 +37,7 @@ pub fn from_bytes(c: &[u8], loca_offsets: Vec<Option<u32>>) -> Result<glyf, Dese
 /// loca_offsets must be obtained from the `loca` table.
 pub fn from_rc(
     c: &mut ReaderContext,
-    loca_offsets: Vec<Option<u32>>,
+    loca_offsets: &[Option<u32>],
 ) -> Result<glyf, DeserializationError> {
     let mut res = glyf { glyphs: Vec::new() };
     for item in loca_offsets {
@@ -54,7 +54,7 @@ pub fn from_rc(
             }),
             Some(item) => {
                 let old = c.ptr;
-                c.ptr = item as usize;
+                c.ptr = *item as usize;
                 let glyph: Glyph = c.de()?;
                 res.glyphs.push(glyph);
                 c.ptr = old;
@@ -199,8 +199,8 @@ impl glyf {
 
 #[cfg(test)]
 mod tests {
+    use crate::font;
     use crate::tables::glyf::{Component, ComponentFlags, Glyph, Point};
-    use crate::{font, tag};
 
     #[test]
     fn glyf_de() {
@@ -376,13 +376,9 @@ mod tests {
             0x01, 0x03, 0x0b, 0x64, 0x6f, 0x6c, 0x6c, 0x61, 0x72, 0x2e, 0x62, 0x6f, 0x6c, 0x64,
             0x09, 0x61, 0x63, 0x75, 0x74, 0x65, 0x63, 0x6f, 0x6d, 0x62,
         ];
-        let mut deserialized: font::Font = otspec::de::from_bytes(&binary_font).unwrap();
+        let deserialized: font::Font = otspec::de::from_bytes(&binary_font).unwrap();
         deserialized.fully_deserialize();
-        let glyf = deserialized
-            .get_table(tag!("glyf"))
-            .unwrap()
-            .unwrap()
-            .glyf_unchecked();
+        let glyf = deserialized.tables.glyf().unwrap().unwrap();
         /*
         <TTGlyph name="A" xMin="5" yMin="0" xMax="751" yMax="700">
           <contour>

--- a/src/tables/gvar.rs
+++ b/src/tables/gvar.rs
@@ -12,6 +12,9 @@ use std::convert::TryInto;
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
 
+/// The 'gvar' OpenType tag.
+pub const TAG: Tag = crate::tag!("gvar");
+
 pub(crate) type Coords = Vec<(int16, int16)>;
 pub(crate) type CoordsAndEndsVec = Vec<(Coords, Vec<usize>)>;
 

--- a/src/tables/head.rs
+++ b/src/tables/head.rs
@@ -2,6 +2,9 @@ use otspec::types::*;
 use otspec::Deserializer;
 use otspec_macros::tables;
 
+/// The 'head' OpenType tag.
+pub const TAG: Tag = crate::tag!("head");
+
 tables!(head {
     uint16 majorVersion
     uint16 minorVersion

--- a/src/tables/hhea.rs
+++ b/src/tables/hhea.rs
@@ -2,6 +2,9 @@ use otspec::types::*;
 use otspec::Deserializer;
 use otspec_macros::tables;
 
+/// The 'hhea' OpenType tag.
+pub const TAG: Tag = crate::tag!("hhea");
+
 tables!(hhea {
     uint16 majorVersion
     uint16 minorVersion

--- a/src/tables/hmtx.rs
+++ b/src/tables/hmtx.rs
@@ -2,6 +2,9 @@ use otspec::types::*;
 use otspec::{DeserializationError, Deserializer, ReaderContext, Serialize};
 use otspec_macros::{Deserialize, Serialize};
 
+/// The 'hmtx' OpenType tag.
+pub const TAG: Tag = crate::tag!("hmtx");
+
 /// A single horizontal metric
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[allow(non_snake_case)]

--- a/src/tables/loca.rs
+++ b/src/tables/loca.rs
@@ -7,7 +7,7 @@ pub const TAG: otspec::types::Tag = crate::tag!("loca");
 ///
 /// [`loca`]: https://docs.microsoft.com/en-us/typography/opentype/spec/loca
 #[allow(non_snake_case, non_camel_case_types)]
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct loca {
     /// The offset position of each glyph in the font.
     ///

--- a/src/tables/loca.rs
+++ b/src/tables/loca.rs
@@ -1,5 +1,8 @@
 use otspec::{DeserializationError, Deserializer, ReaderContext, Serialize};
 
+/// The 'loca' OpenType tag.
+pub const TAG: otspec::types::Tag = crate::tag!("loca");
+
 /// A [`loca`] table.
 ///
 /// [`loca`]: https://docs.microsoft.com/en-us/typography/opentype/spec/loca

--- a/src/tables/maxp.rs
+++ b/src/tables/maxp.rs
@@ -32,7 +32,7 @@ maxp10 {
 /// The `maxp` table comes in two versions, 0.5 and 1.0, which have
 /// different fields. The enum allows a single maxp object to represent
 /// both versions.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum MaxpVariant {
     /// This table is a maxp version 0.5
     Maxp05(maxp05),
@@ -51,7 +51,7 @@ impl Serialize for MaxpVariant {
 
 /// A maxp table, regardless of version.
 #[allow(non_snake_case, non_camel_case_types)]
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, PartialEq)]
 pub struct maxp {
     /// The version number as a fixed U16F16 value (for ease of serialization)
     #[otspec(with = "Version16Dot16")]

--- a/src/tables/maxp.rs
+++ b/src/tables/maxp.rs
@@ -2,6 +2,9 @@ use otspec::types::*;
 use otspec::{DeserializationError, Deserialize, Deserializer, ReaderContext, Serialize};
 use otspec_macros::{tables, Serialize};
 
+/// The 'maxp' OpenType tag.
+pub const TAG: Tag = crate::tag!("maxp");
+
 tables!(
 maxp05 {
     uint16  numGlyphs

--- a/src/tables/name.rs
+++ b/src/tables/name.rs
@@ -120,7 +120,7 @@ tables!(
 );
 
 /// A single name record to be placed inside the name table
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[allow(non_snake_case)]
 pub struct NameRecord {
     /// Platform ID (0=Unicode, 1=Macintosh, 3=Windows)
@@ -160,7 +160,7 @@ impl NameRecord {
 }
 
 /// Represents a font's name (Naming) table
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[allow(non_camel_case_types)]
 pub struct name {
     /// A set of name records.

--- a/src/tables/name.rs
+++ b/src/tables/name.rs
@@ -8,6 +8,9 @@ use otspec::{
 };
 use otspec_macros::tables;
 
+/// The 'name' OpenType tag.
+pub const TAG: Tag = crate::tag!("name");
+
 fn get_encoding(platform_id: u16, encoding_id: u16) -> EncodingRef {
     if platform_id == 0 {
         return UTF_16BE;

--- a/src/tables/os2.rs
+++ b/src/tables/os2.rs
@@ -6,6 +6,9 @@ use otspec::{
 use otspec_macros::tables;
 use std::collections::{BTreeMap, HashSet};
 
+/// The 'OS/2' OpenType tag.
+pub const TAG: Tag = crate::tag!("OS/2");
+
 tables!(
     Panose {
         u8 panose0

--- a/src/tables/os2.rs
+++ b/src/tables/os2.rs
@@ -74,7 +74,7 @@ tables!(
 );
 
 /// Represents a font's OS/2 (OS/2 and Windows Metrics) table
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[allow(non_camel_case_types, non_snake_case)]
 pub struct os2 {
     /// Table version (between 0 and 5)

--- a/src/tables/post.rs
+++ b/src/tables/post.rs
@@ -284,8 +284,8 @@ tables!( postcore {
 });
 
 /// Represents the font's post (PostScript) table
+#[derive(Clone, Debug, PartialEq)]
 #[allow(non_snake_case, non_camel_case_types)]
-#[derive(Debug, PartialEq)]
 pub struct post {
     /// version of the post table (either 0.5 or 1.0), expressed as a Fixed::U16F16.
     pub version: U16F16,

--- a/src/tables/post.rs
+++ b/src/tables/post.rs
@@ -4,6 +4,9 @@ use otspec::{
 };
 use otspec_macros::tables;
 
+/// The 'post' OpenType tag.
+pub const TAG: Tag = crate::tag!("post");
+
 /// The list of 258 standard Macintosh glyph names.
 /// Names not in this list will be stored separately in the post table if
 /// version==2


### PR DESCRIPTION
*This includes the commit from #54; if we don't want that PR (or want some alternative form) I'll rework this accordingly.*

This is the impl of a new API for accessing tables.

I haven't fixed the various other projects & crates yet, because I thought it might be helpful to open this for discussion while I plod through getting CI to pass.

Highlights
- there's a new `TableSet` type that coordinates storing and loading tables.
- tables are lazily loaded on first access, and we use interior mutability so that table getters don't require `&mut self`.
- all tables are stored behind shared pointers, so you never need to hold on to a borrow of the `TableSet` or `Font`.
- tables have *transparent* copy-on-write semantics: after a table has been retrieved from a font, the first time it is mutated we do a deep clone of the source table. (this is maybe a bit controversial, it's a pattern I haven't seen before and is a bit 'magical')
- this means that you cannot mutate a table "in place"; you need to retrieve it, modify it, and then insert it back into the font.
- access to known tables is provided via methods on `TableSet`, with the signature,
  ```rust
  fn GPOS(&self) -> Result<Option<CowPtr<GPOS>>, DeserializationError> { .. }
  ```
- for unknown tables there is still a `get` method


There are a few rough edges. 

- It's annoying that we need to always return `Result<Option<T>>`. I've been daydreaming about having two forms of `Font`, one which has been preloaded and one which hasn't; methods on the former would be infallible, and maybe we could also do things like guarantee that all of the required tables are present? I don't want to worry about this too much right now, but wanted to at least mention it.

- I'm also not totally sure about the process of mutating tables and mutating fonts; I can imagine a different API where there `Font` is read-only, and if you want to mutate you have to use an explicit `FontBuilder` method, and then there would be a `to_builder()` method on `Font` for constructing that; you would then add or remove tables as desired before calling a `build()` method that would give you a new font. This would be slightly more cumbersome but would also be clearer with regards to the fact that if you get a table and then mutate it you need to put it back in the font for anything to change?


Anyway, overall I think this should be quite a bit easier to use.

Simon if you'd like to chat about this at some point let me know!